### PR TITLE
simplify notations

### DIFF
--- a/altprob_model.v
+++ b/altprob_model.v
@@ -19,6 +19,7 @@ Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
 Local Open Scope proba_scope.
+Local Open Scope category_scope.
 
 Section P_delta_altProbMonad.
 Local Open Scope R_scope.
@@ -79,7 +80,7 @@ Qed.
 
 Section bindaltDl.
 Import category.
-Import homcomp_notation.
+Import comps_notation.
 Local Notation F1 := free_semiCompSemiLattConvType.
 Local Notation F0 := free_convType.
 Local Notation FC := free_choiceType.
@@ -88,8 +89,8 @@ Local Notation U0 := forget_convType.
 Local Notation U1 := forget_semiCompSemiLattConvType.
 
 Lemma affine_F1e0U1PD_alt T (u v : gcm (gcm T)) :
-  [fun of F1 # eps0 (U1 (P_delta_left T))] (u [+] v) =
-  [fun of F1 # eps0 (U1 (P_delta_left T))] u [+] [fun of F1 # eps0 (U1 (P_delta_left T))] v.
+  (F1 # eps0 (U1 (P_delta_left T))) (u [+] v) =
+  (F1 # eps0 (U1 (P_delta_left T))) u [+] (F1 # eps0 (U1 (P_delta_left T))) v.
 Proof.
 rewrite [in LHS]/lub_binary -lub_op_hull.
 have huv : NECSet.class_of (hull [set u; v]).
@@ -97,21 +98,21 @@ have huv : NECSet.class_of (hull [set u; v]).
   rewrite hull_eq0; apply/eqP => /(congr1 (fun x => x u)).
   by rewrite propeqE => -[X _]; apply X; left.
 have @UV : necset_semiCompSemiLattConvType (F1 ((F0 \O U0) (U1 (P_delta_left T)))) := NECSet.Pack huv.
-transitivity (|_| ([fun of F1 # eps0 (U1 (P_delta_left T))] @` UV)%:ne).
+transitivity (|_| ((F1 # eps0 (U1 (P_delta_left T))) @` UV)%:ne).
   rewrite -(apply_affine (F1 # eps0 (U1 (P_delta_left T))) UV).
-  congr ([fun of _] _); congr (|_| _); exact/neset_ext.
+  congr (_ _); congr (|_| _); exact/neset_ext.
 rewrite [in RHS]/lub_binary.
-transitivity (|_| (hull ([fun of F1 # eps0 (U1 (P_delta_left T))] @` [set u; v]))%:ne).
+transitivity (|_| (hull ((F1 # eps0 (U1 (P_delta_left T))) @` [set u; v]))%:ne).
   congr (|_| _%:ne); apply/neset_ext => /=.
-  have /image_preserves_convex_hull' : affine_function [fun of F1 # eps0 (U1 (P_delta_left T))].
+  have /image_preserves_convex_hull' : affine_function (F1 # eps0 (U1 (P_delta_left T))).
     move=> a b p; rewrite /affine_function_at => /=.
     rewrite /free_semiCompSemiLattConvType_mor /=; unlock; rewrite /free_semiCompSemiLattConvType_mor' /=.
     apply/necset_ext => /=; rewrite funeqE => X; rewrite propeqE; split.
     - case=> D.
       rewrite /Conv /= necset_convType.convE => -[x0 [y0 [x0a [y0a]]]] ->{D} <-{X}.
       rewrite /Conv /= necset_convType.convE.
-      exists ([fun of eps0 (necset_semiCompSemiLattConvType (FSDist_convType (choice_of_Type T)))] x0),
-        ([fun of eps0 (necset_semiCompSemiLattConvType (FSDist_convType (choice_of_Type T)))] y0).
+      exists ((eps0 (necset_semiCompSemiLattConvType (FSDist_convType (choice_of_Type T)))) x0),
+        ((eps0 (necset_semiCompSemiLattConvType (FSDist_convType (choice_of_Type T)))) y0).
       split.
         by rewrite in_setE /=; exists x0 => //; rewrite -in_setE.
       split.
@@ -139,8 +140,8 @@ rewrite funeqE => /= X; rewrite propeqE; split.
 Qed.
 
 Lemma affine_e1PD_alt T (x y : El (F1 (FId (U1 (P_delta_left T))))) :
-  [fun of eps1 (P_delta_left T)] (x [+] y) =
-  [fun of eps1 (P_delta_left T)] x [+] [fun of eps1 (P_delta_left T)] y.
+  (eps1 (P_delta_left T)) (x [+] y) =
+  (eps1 (P_delta_left T)) x [+] (eps1 (P_delta_left T)) y.
 Proof.
 rewrite /lub_binary eps1E -lub_op_setU.
 transitivity (|_| (hull (\bigcup_(x0 in [set x; y]) x0))%:ne); last first.
@@ -209,7 +210,7 @@ Qed.
 
 Section bindchoiceDl.
 Import category.
-Import homcomp_notation.
+Import comps_notation.
 Local Notation F1 := free_semiCompSemiLattConvType.
 Local Notation F0 := free_convType.
 Local Notation FC := free_choiceType.
@@ -218,8 +219,8 @@ Local Notation U0 := forget_convType.
 Local Notation U1 := forget_semiCompSemiLattConvType.
 
 Lemma affine_F1e0U1PD_conv T (u v : gcm (gcm T)) p :
-  [fun of F1 # eps0 (U1 (P_delta_left T))] (u <|p|> v) =
-  [fun of F1 # eps0 (U1 (P_delta_left T))] u <|p|> [fun of F1 # eps0 (U1 (P_delta_left T))] v.
+  (F1 # eps0 (U1 (P_delta_left T))) (u <|p|> v) =
+  (F1 # eps0 (U1 (P_delta_left T))) u <|p|> (F1 # eps0 (U1 (P_delta_left T))) v.
 Proof.
 rewrite /Conv /= /free_semiCompSemiLattConvType_mor /=; unlock.
 rewrite /free_semiCompSemiLattConvType_mor' /=; apply/necset_ext => /=.
@@ -243,8 +244,8 @@ by rewrite eps0''_affine.
 Qed.
 
 Lemma affine_e1PD_conv T (x y : El (F1 (FId (U1 (P_delta_left T))))) p :
-  [fun of eps1 (P_delta_left T)] (x <|p|> y) =
-  [fun of eps1 (P_delta_left T)] x <|p|> [fun of eps1 (P_delta_left T)] y.
+  (eps1 (P_delta_left T)) (x <|p|> y) =
+  (eps1 (P_delta_left T)) x <|p|> (eps1 (P_delta_left T)) y.
 Proof.
 rewrite eps1E -lub_op_conv_setD; congr (|_| _); apply/neset_ext => /=.
 by rewrite -necset_convType.conv_conv_set.

--- a/gcm_model.v
+++ b/gcm_model.v
@@ -107,6 +107,8 @@ Global Arguments convn1Eq [n g d Hn1].
 End misc_convex.
 End TODO_move_to_other_file.
 
+Local Open Scope category_scope.
+
 Section choiceType_as_a_category.
 Import category.
 Definition choiceType_category_mixin : Category.mixin_of choiceType :=
@@ -134,8 +136,8 @@ Definition free_choiceType : functor CT CC :=
 
 Lemma free_choiceType_mor_comp_fun (a b c : Type) (g : {hom b, c})
       (h : {hom a, b}):
-  [fun of free_choiceType_mor [hom of [fun of g] \o [fun of h]]] =
-  [fun of free_choiceType_mor g] \o [fun of free_choiceType_mor h].
+  free_choiceType_mor [hom g \o h] =
+  (free_choiceType_mor g) \o (free_choiceType_mor h) :> (_ -> _).
 Proof. by rewrite free_choiceType_mor_comp. Qed.
 
 Let h (a b : CC) (f : {hom CC; a, b}) : {hom CT; Choice.sort a , Choice.sort b} :=
@@ -175,7 +177,7 @@ Definition etaC: FId ~> UC \O FC :=
 Lemma etaCE (T : Type) : etaC T = idfun :> (_ -> _).
 Proof. by rewrite /etaC; unlock. Qed.
 
-Import homcomp_notation.
+Import comps_notation.
 Lemma triLC : TriangularLaws.left etaC epsC.
 Proof. by move=> c; rewrite etaCE epsCE. Qed.
 Lemma triRC : TriangularLaws.right etaC epsC.
@@ -200,11 +202,11 @@ Definition free_convType_mor (A B : choiceType) (f : {hom A, B}) :
   {hom FSDist_convType A, FSDist_convType B}.
 refine (@Hom.Pack CV _ _ _ (FSDistfmap f) _).
 (* TODO: try to use a variant of FSDistfmap_affine? *)
-exact: (fun x y t => ConvFSDist.bind_left_distr t x y (fun a : A => FSDist1.d ([fun of f] a))).
+exact: (fun x y t => ConvFSDist.bind_left_distr t x y (fun a : A => FSDist1.d (f a))).
 Defined.
 
 Lemma mem_finsupp_free_convType_mor (A B : choiceType) (f : A -> B) (d : {dist A}) (x : finsupp d) :
-  f (fsval x) \in finsupp ([fun of free_convType_mor (hom_choiceType f)] d).
+  f (fsval x) \in finsupp ((free_convType_mor (hom_choiceType f)) d).
 Proof.
 rewrite /= FSDistBind.supp imfset_id.
 apply/bigfcupP; exists (FSDist1.d (f (fsval x))).
@@ -236,8 +238,8 @@ Definition free_convType : functor CC CV :=
 
 Lemma free_convType_mor_comp_fun (A B C : choiceType) (g : {hom B, C})
       (h : {hom A, B}):
-  [fun of free_convType_mor [hom of [fun of g] \o [fun of h]]] =
-  [fun of free_convType_mor g] \o [fun of free_convType_mor h].
+  free_convType_mor [hom g \o h] =
+  (free_convType_mor g) \o (free_convType_mor h) :> (_ -> _).
 Proof. by rewrite free_convType_mor_comp. Qed.
 
 Let m1 : CV -> CC := idfun.
@@ -309,7 +311,7 @@ Proof. by rewrite /eta0; unlock. Qed.
 Lemma eta0E (T : choiceType) : eta0 T = (@FSDist1.d _) :> (_ -> _).
 Proof. by rewrite /eta0; unlock. Qed.
 
-Import homcomp_notation.
+Import comps_notation.
 Import ScaledConvex.
 Local Open Scope fset_scope.
 Local Open Scope R_scope.
@@ -370,7 +372,7 @@ Local Open Scope convex_scope.
 Local Notation CV := convType_category.
 Local Notation CS := semiCompSemiLattConvType_category.
 
-Lemma hom_affine_function (A B : convType) (f : {hom A, B}) : affine_function [fun of f].
+Lemma hom_affine_function (A B : convType) (f : {hom A, B}) : affine_function f.
 Proof. by case: f. Qed.
 
 (* the morphism part of necset *)
@@ -465,7 +467,7 @@ Local Notation F1 := free_semiCompSemiLattConvType.
 
 Lemma free_semiCompSemiLattConvType_mor_comp_fun (a b c : convType)
     (g : {hom b, c}) (h : {hom a, b}):
-  [fun of F1 # [hom of [fun of g] \o [fun of h]]] = [fun of F1 # g] \o [fun of F1 # h].
+  (F1 # [hom g \o h]) = (F1 # g) \o (F1 # h) :> (_ -> _).
 Proof. by rewrite /Fun /= free_semiCompSemiLattConvType_mor_comp. Qed.
 
 Let m2 : CS -> CV := id.
@@ -574,7 +576,7 @@ Proof. by rewrite /eta1; unlock. Qed.
 Lemma eta1E'' (C : convType) (x : C) : eta1 C x = necset1 x.
 Proof. by rewrite /eta1; unlock. Qed.
 
-Import homcomp_notation.
+Import comps_notation.
 Lemma necset1E (T : convType) (t : T) : necset1 t = [set t] :> set T.
 Proof. by []. Qed.
 Lemma triL1 : TriangularLaws.left eta1 eps1.
@@ -697,17 +699,17 @@ Lemma gcm_joinE : Join X = necset_join X.
 Import category.
 apply/necset_ext.
 rewrite /= /Monad_of_category_monad.join /= !HCompId !HIdComp eps1E.
-have-> : [fun of AdjComp.F F0 F1
+have-> : AdjComp.F F0 F1
                 # epsC
                     (AdjComp.G U0 U1
                        (necset_semiCompSemiLattConvType
-                          (FSDist_convType (choice_of_Type T))))] = idfun.
+                          (FSDist_convType (choice_of_Type T)))) = idfun :> (_ -> _).
 - by rewrite -[in RHS]functor_id; congr Fun; apply/hom_ext; rewrite epsCE.
-have-> : [fun of F1
+have-> : F1
               # eps0
               (U1
-                 (necset_semiCompSemiLattConvType (FSDist_convType (choice_of_Type T))))] =
-         @necset_join.F1join0 _.
+                 (necset_semiCompSemiLattConvType (FSDist_convType (choice_of_Type T)))) =
+         @necset_join.F1join0 _ :> (_ -> _).
 - apply funext=> x; apply necset_ext.
   rewrite /= /necset_join.F1join0' /=.
   rewrite /free_semiCompSemiLattConvType_mor; unlock=> /=.

--- a/monad_lib.v
+++ b/monad_lib.v
@@ -8,6 +8,7 @@ Require Import monae_lib hierarchy.
 (******************************************************************************)
 (*  Properties and examples of functors, natural transformations, and monads  *)
 (*                                                                            *)
+(*                    s \h g == horizontal composition                        *)
 (*                    F ## n == application of functor F to natural           *)
 (*                              transformation n                              *)
 (*                    F -| G == adjoint functors                              *)


### PR DESCRIPTION
- change the [fun of f] notation to [fn f] in printing only
- remove \\h but keep equivalence between the two formulations of horizontal composition as a lemma
- change notation [hom of f] to [hom ]
- change notation [homcomp _] to [\o _]
- various renaming for homogeneity (funcomp_hom to homcomp0, etc.)