### PR TITLE
notation improvements and compatibility with infotheo 0.3.1

### DIFF
--- a/altprob_model.v
+++ b/altprob_model.v
@@ -153,16 +153,16 @@ Lemma choiceA A (p q r s : prob) (x y z : gcm A) :
 Proof.
 case=> H1 H2.
 case/boolP : (r == 0%:pr) => r0.
-  have p0 : p = 0%:pr by apply/prob_ext => /=; rewrite H1 (eqP r0) mul0R.
-  rewrite p0 choice0 (eqP r0) choice0 (_ : q = s) //; apply/prob_ext => /=.
+  have p0 : p = 0%:pr by apply/val_inj; rewrite /= H1 (eqP r0) mul0R.
+  rewrite p0 choice0 (eqP r0) choice0 (_ : q = s) //; apply/val_inj => /=.
   by move: H2; rewrite p0 onem0 mul1R => /(congr1 onem); rewrite !onemK.
 case/boolP : (s == 0%:pr) => s0.
-  have p0 : p = 0%:pr by apply/prob_ext => /=; rewrite H1 (eqP s0) mulR0.
-  rewrite p0 (eqP s0) 2!choice0 (_ : q = 0%:pr) ?choice0 //; apply/prob_ext.
+  have p0 : p = 0%:pr by apply/val_inj; rewrite /= H1 (eqP s0) mulR0.
+  rewrite p0 (eqP s0) 2!choice0 (_ : q = 0%:pr) ?choice0 //; apply/val_inj.
   move: H2; rewrite p0 onem0 mul1R (eqP s0) onem0 => /(congr1 onem).
   by rewrite onemK onem1.
 rewrite /choice convA (@r_of_pq_is_r _ _ r s) //; congr ((_ <| _ |> _) <| _ |> _).
-by apply/prob_ext; rewrite s_of_pqE -H2 onemK.
+by apply/val_inj; rewrite /= s_of_pqE -H2 onemK.
 Qed.
 
 Section bindchoiceDl.
@@ -264,6 +264,6 @@ rewrite 2!in_setE 2!necset1E => -[] -> [] ->.
 move/(congr1 (fun x : {dist (choice_of_Type bool)} => x true)) => /=.
 rewrite /Conv /= !ConvFSDist.dE !FSDist1.dE !inE !eqxx.
 case/boolP: ((true : choice_of_Type bool) == false) => [/eqP//|].
-by rewrite !mulR1 !mulR0 !addR0 => _ ?; apply prob_ext.
+by rewrite !mulR1 !mulR0 !addR0 => _ ?; exact/val_inj.
 Qed.
 End examples.

--- a/coq-monae.opam
+++ b/coq-monae.opam
@@ -29,7 +29,7 @@ depends: [
   "coq-mathcomp-solvable" { (>= "1.12.0" & < "1.13~") }
   "coq-mathcomp-field" { (>= "1.12.0" & < "1.13~") }
   "coq-mathcomp-analysis" { (>= "0.3.4" & < "0.4~") }
-  "coq-infotheo" { >= "0.3" & < "0.4~"}
+  "coq-infotheo" { >= "0.3.1" & < "0.4~"}
   "coq-paramcoq" { >= "1.1.2" & < "1.2~" }
 ]
 

--- a/example_monty.v
+++ b/example_monty.v
@@ -539,7 +539,7 @@ transitivity (uniform def [:: h; d] >>= (fun t => if t == h then Fail else Ret t
   move: (Set3.filter1_another card_door hp); rewrite -/doors -Hd => -[] -> //.
   by rewrite uniform2.
 rewrite uniform_cons (_ : _%:pr = (/ 2)%:pr)%R; last first.
-  by apply prob_ext => /=; lra.
+  by apply val_inj => /=; lra.
 rewrite uniform_singl // [head _ _]/= prob_bindDl 2!bindretf eqxx ifF //.
 by apply/negbTE/(Set3.head_filter card_door); rewrite inE eqxx.
 Qed.

--- a/gcm_model.v
+++ b/gcm_model.v
@@ -118,23 +118,26 @@ Definition choiceType_category_mixin : Category.mixin_of choiceType :=
     (fun _ _ _ => True) (fun=> I) (fun _ _ _ _ _ _ _ => I).
 Canonical choiceType_category := Category.Pack choiceType_category_mixin.
 Definition hom_choiceType (A B : choiceType) (f : A -> B) : {hom A, B} :=
-  HomPack (I : InHom (f : el A -> el B)).
+  HomPack A B f I.
 End choiceType_as_a_category.
+
+Notation CC := choiceType_category.
 
 Section free_choiceType_functor.
 Import category.
 Local Notation m := choice_of_Type.
-Local Notation CC := choiceType_category.
-Local Notation CT := Type_category.
 
 Definition free_choiceType_mor (T U : CT) (f : {hom T, U}) :
   {hom m T, m U} := hom_choiceType (f : m T -> m U).
+
 Lemma free_choiceType_mor_id : FunctorLaws.id free_choiceType_mor.
 Proof. by move=> a; rewrite hom_ext. Qed.
+
 Lemma free_choiceType_mor_comp : FunctorLaws.comp free_choiceType_mor.
 Proof. by move=> a b c g h; rewrite hom_ext. Qed.
-Definition free_choiceType : functor CT CC :=
-  Functor.Pack (Functor.Mixin free_choiceType_mor_id free_choiceType_mor_comp).
+
+Definition free_choiceType : {functor CT -> CC} :=
+  Functor free_choiceType_mor_id free_choiceType_mor_comp.
 
 Lemma free_choiceType_mor_comp_fun (a b c : Type) (g : {hom b, c})
       (h : {hom a, b}):
@@ -142,45 +145,43 @@ Lemma free_choiceType_mor_comp_fun (a b c : Type) (g : {hom b, c})
   (free_choiceType_mor g) \o (free_choiceType_mor h) :> (_ -> _).
 Proof. by rewrite free_choiceType_mor_comp. Qed.
 
-Let h (a b : CC) (f : {hom CC; a, b}) : {hom CT; Choice.sort a , Choice.sort b} :=
-  HomPack (I : InHom (FId # f : el (C:=CT) a -> el b)).
+Let h (a b : CC) (f : {hom a, b}) : {hom CT; a, b} :=
+  HomPack (a : CT) (b : _) (FId # f) I.
+
 Lemma h_id : FunctorLaws.id h. Proof. by move=> *; apply hom_ext. Qed.
+
 Lemma h_comp : FunctorLaws.comp h. Proof. by move=> *; apply hom_ext. Qed.
-Definition forget_choiceType : functor CC CT :=
-  Functor.Pack (Functor.Mixin h_id h_comp).
+
+Definition forget_choiceType : {functor CC -> CT} := Functor h_id h_comp.
+
 Lemma forget_choiceTypeE :
   (forall a : CC, forget_choiceType a = a)
-  /\ (forall a b (f : {hom CC; a , b}), forget_choiceType # f = f :> (a -> b)).
+  /\ (forall (a b : CC) (f : {hom CC; a , b}), forget_choiceType # f = f :> (a -> b)).
 Proof. by []. Qed.
+
 End free_choiceType_functor.
 
 Section epsC_etaC.
 Import category.
-Local Notation CC := choiceType_category.
-Local Notation CT := Type_category.
 Local Notation FC := free_choiceType.
 Local Notation UC := forget_choiceType.
 
-Let epsC'' {T : choiceType} : FC T -> T := idfun.
-
-Let epsC' : FC \O UC ~~> FId := fun T => @Hom.Pack CC _ _ _ (@epsC'' T) I.
+Let epsC' : FC \O UC ~~> FId := fun A : CC => HomPack ((FC \O UC) A) (FId A) idfun I.
 
 Lemma epsC'_natural : naturality _ _ epsC'.
 Proof. by []. Qed.
 
-Definition epsC : FC \O UC ~> FId := locked
-  (Natural.Pack (Natural.Mixin epsC'_natural)).
+Definition epsC : FC \O UC ~> FId := locked (Natural epsC'_natural).
 
 Lemma epsCE (T : choiceType) : epsC T = idfun :> (_ -> _).
 Proof. by rewrite /epsC; unlock. Qed.
 
-Let etaC' : FId ~~> UC \O FC := fun _ => @Hom.Pack CT _ _ _ idfun I.
+Let etaC' : FId ~~> UC \O FC := fun (_ : CT) => HomPack (FId _) ((UC \O FC) _) idfun I.
 
 Lemma etaC'_natural : naturality _ _ etaC'.
 Proof. by []. Qed.
 
-Definition etaC : FId ~> UC \O FC := locked
-  (Natural.Pack (Natural.Mixin etaC'_natural)).
+Definition etaC : FId ~> UC \O FC := locked (Natural etaC'_natural).
 
 Lemma etaCE (T : Type) : etaC T = idfun :> (_ -> _).
 Proof. by rewrite /etaC; unlock. Qed.
@@ -203,21 +204,17 @@ Qed.
 Canonical convType_category := Category.Pack convType_category_mixin.
 End convType_as_a_category.
 
+Notation CV := convType_category.
+
 Section free_convType_functor.
 Import category.
-Local Notation CC := choiceType_category.
-Local Notation CV := convType_category.
 
-(* morphism part of FSDist *)
-Definition free_convType_mor (A B : choiceType) (f : {hom A, B}) :
-  {hom FSDist_convType A, FSDist_convType B} :=
-  @Hom.Pack CV _ _ _ (FSDistfmap f)
-    (fun t x y => ConvFSDist.bind_left_distr t x y (fun a => FSDist1.d (f a))).
-    (* NB: FSDistfmap_affine already defined in infotheo/necset.v *)
+Definition free_convType_mor (A B : CC) (f : {hom A, B}) : {hom {dist A}, {dist B}} :=
+  HomPack {dist A} {dist B} (FSDistfmap f) (FSDistfmap_affine f).
 
-Lemma mem_finsupp_free_convType_mor (A B : choiceType) (f : A -> B)
+Lemma mem_finsupp_free_convType_mor (A B : CC) (f : A -> B)
     (d : {dist A}) (x : finsupp d) :
-  f (fsval x) \in finsupp ((free_convType_mor (hom_choiceType f)) d).
+  f (fsval x) \in finsupp (free_convType_mor (hom_choiceType f) d).
 Proof.
 rewrite /= FSDistBind.supp imfset_id.
 apply/bigfcupP; exists (FSDist1.d (f (fsval x))).
@@ -227,7 +224,7 @@ Qed.
 
 (* free_convType_mor induces maps between supports *)
 Definition free_convType_mor_supp
-  (A B : choiceType) (f : A -> B(*{hom A , B}*)) (d : {dist A}) (x : finsupp d)
+  (A B : CC) (f : A -> B(*{hom A , B}*)) (d : {dist A}) (x : finsupp d)
   : [finType of finsupp ((free_convType_mor (hom_choiceType f)) d)] :=
   FSetSub (mem_finsupp_free_convType_mor f x).
 Global Arguments free_convType_mor_supp [A B] f d.
@@ -242,25 +239,23 @@ Qed.
 Lemma free_convType_mor_comp : FunctorLaws.comp free_convType_mor.
 Proof. by move=> a b c g h; rewrite hom_ext /= FSDistfmap_comp. Qed.
 
-Definition free_convType : functor CC CV :=
-  Functor.Pack (Functor.Mixin free_convType_mor_id free_convType_mor_comp).
+Definition free_convType : {functor CC -> CV} :=
+  Functor free_convType_mor_id free_convType_mor_comp.
 
-Lemma free_convType_mor_comp_fun (A B C : choiceType) (g : {hom B, C})
-      (h : {hom A, B}):
+Lemma free_convType_mor_comp_fun (A B C : CC) (g : {hom B, C}) (h : {hom A, B}) :
   free_convType_mor [hom g \o h] =
   (free_convType_mor g) \o (free_convType_mor h) :> (_ -> _).
 Proof. by rewrite free_convType_mor_comp. Qed.
 
 Let m1 : CV -> CC := idfun.
-Let h1 := fun (a b : CV) (f : {hom CV; a, b}) =>
-  @Hom.Pack CC a b _ f I : {hom CC; m1 a , m1 b}.
+Let h1 := fun (a b : CV) (f : {hom CV; a, b}) => HomPack (m1 a) (m1 b) f I.
 Lemma h1_id : FunctorLaws.id h1. Proof. by move=> *; apply hom_ext. Qed.
 Lemma h1_comp : FunctorLaws.comp h1. Proof. by move=> *; apply hom_ext. Qed.
-Definition forget_convType : functor CV CC :=
-  Functor.Pack (Functor.Mixin h1_id h1_comp).
+Definition forget_convType : {functor CV -> CC} :=
+  Functor h1_id h1_comp.
 Lemma forget_convTypeE :
   (forall a : CV, forget_convType a = a)
-  /\ (forall a b (f : {hom CV; a , b}), forget_convType # f = f :> (a -> b)).
+  /\ (forall (a b : CV) (f : {hom CV; a , b}), forget_convType # f = f :> (a -> b)).
 Proof. by []. Qed.
 End free_convType_functor.
 
@@ -282,11 +277,9 @@ Local Open Scope R_scope.
 Local Open Scope convex_scope.
 Local Notation F0 := free_convType.
 Local Notation U0 := forget_convType.
-Local Notation CC := choiceType_category.
-Local Notation CV := convType_category.
 
 Let eps0' : F0 \O U0 ~~> FId :=
-  fun a => @Hom.Pack CV _ _ _ _ (@Convn_of_FSDist_affine (FId a)).
+  fun a => HomPack ((F0 \O U0) a) (FId a) (@Convn_of_FSDist a) (@Convn_of_FSDist_affine (FId a)).
 
 Let eps0'_natural : naturality _ _ eps0'.
 Proof.
@@ -294,22 +287,20 @@ move=> C D f; rewrite FCompE /= /id_f; apply funext => d /=.
 by rewrite Convn_of_FSDist_FSDistfmap.
 Qed.
 
-Definition eps0 : F0 \O U0 ~> FId := locked
-  (Natural.Pack (Natural.Mixin eps0'_natural)).
+Definition eps0 : F0 \O U0 ~> FId := locked (Natural eps0'_natural).
 
 Lemma eps0E (C : convType) : eps0 C = @Convn_of_FSDist C :> (_ -> _).
 Proof. by rewrite /eps0; unlock. Qed.
 
 Let eta0' : FId ~~> U0 \O F0 :=
-  fun C => @Hom.Pack CC _ _ _ (fun x => FSDist1.d x) I.
+  fun T => HomPack (FId T) ((U0 \O F0) T) (fun x => FSDist1.d x) I.
 
 Lemma eta0'_natural : naturality _ _ eta0'.
 Proof.
 by move=> a b h; rewrite funeqE=> x; rewrite FIdf /eta0' /= FSDistfmap1.
 Qed.
 
-Definition eta0 : FId ~> U0 \O F0 := locked
-  (Natural.Pack (Natural.Mixin eta0'_natural)).
+Definition eta0 : FId ~> U0 \O F0 := locked (Natural eta0'_natural).
 
 Lemma eta0E (T : choiceType) : eta0 T = @FSDist1.d _ :> (_ -> _).
 Proof. by rewrite /eta0; unlock. Qed.
@@ -360,6 +351,8 @@ Canonical semiCompSemiLattConvType_category :=
   Category.Pack semiCompSemiLattConvType_category_mixin.
 End semiCompSemiLattConvType_as_a_category.
 
+Notation CS := semiCompSemiLattConvType_category.
+
 Local Open Scope classical_set_scope.
 Local Open Scope latt_scope.
 
@@ -376,15 +369,13 @@ End hom_biglubmorph.
 Section free_semiCompSemiLattConvType_functor.
 Import category.
 Local Open Scope convex_scope.
-Local Notation CV := convType_category.
-Local Notation CS := semiCompSemiLattConvType_category.
 
 (* the morphism part of necset *)
 Section free_semiCompSemiLattConvType_mor.
 Variables (A B : convType) (f : {hom A , B}).
 
-Definition free_semiCompSemiLattConvType_mor' (X : necset A) :
-  necset B := NECSet.Pack (NECSet.Class
+Definition free_semiCompSemiLattConvType_mor' (X : {necset A}) : {necset B} :=
+  NECSet.Pack (NECSet.Class
     (CSet.Class (is_convex_set_image [affine of f] X))
     (NESet.Mixin (neset_image_neq0 _ _))).
 
@@ -430,10 +421,12 @@ by rewrite image_preserves_convex_hull bigsetU_affine.
 Qed.
 
 Definition free_semiCompSemiLattConvType_mor :
-  {hom necset_semiCompSemiLattConvType A, necset_semiCompSemiLattConvType B} :=
-  locked (@Hom.Pack CS _ _ _ free_semiCompSemiLattConvType_mor'
+  {hom {necset A}, {necset B}} :=
+  locked (HomPack
+    {necset A} {necset B}
+    free_semiCompSemiLattConvType_mor'
     (BiglubAffine.Class free_semiCompSemiLattConvType_mor'_affine
-                     free_semiCompSemiLattConvType_mor'_biglub_morph)).
+                       free_semiCompSemiLattConvType_mor'_biglub_morph)).
 
 Lemma free_semiCompSemiLattConvType_morE (X : necset A) :
   NECSet.mixinType (free_semiCompSemiLattConvType_mor X) = image_neset f X.
@@ -463,9 +456,9 @@ rewrite 2!free_semiCompSemiLattConvType_morE' /= -image_comp.
 by rewrite free_semiCompSemiLattConvType_morE'.
 Qed.
 
-Definition free_semiCompSemiLattConvType : functor CV CS :=
-  Functor.Pack (Functor.Mixin free_semiCompSemiLattConvType_mor_id
-                              free_semiCompSemiLattConvType_mor_comp).
+Definition free_semiCompSemiLattConvType : {functor CV -> CS} :=
+  Functor free_semiCompSemiLattConvType_mor_id
+          free_semiCompSemiLattConvType_mor_comp.
 
 Local Notation F1 := free_semiCompSemiLattConvType.
 
@@ -475,17 +468,16 @@ Lemma free_semiCompSemiLattConvType_mor_comp_fun (a b c : convType)
 Proof. by rewrite /Actm /= free_semiCompSemiLattConvType_mor_comp. Qed.
 
 Let m2 : CS -> CV := id.
-Let h2 := fun (a b : CS) (f : {hom CS; a, b}) =>
-  @Hom.Pack CV a b _ f (BiglubAffine.base (Hom.class f)) : {hom CV; m2 a , m2 b}.
+Let h2 := fun (a b : CS) (f : {hom CS; a, b}) => HomPack (m2 a) (m2 b) f (BiglubAffine.base (Hom.class f)).
 Lemma h2_id : FunctorLaws.id h2. Proof. by move=> *; apply hom_ext. Qed.
 Lemma h2_comp : FunctorLaws.comp h2. Proof. by move=> *; apply hom_ext. Qed.
-Definition forget_semiCompSemiLattConvType : functor CS CV :=
-  Functor.Pack (Functor.Mixin h2_id h2_comp).
+Definition forget_semiCompSemiLattConvType : {functor CS -> CV} :=
+  Functor h2_id h2_comp.
 
 Local Notation U1 := forget_semiCompSemiLattConvType.
 
 Lemma forget_semiCompSemiLattConvTypeE : (forall a : CS, forget_convType a = a)
-  /\ (forall a b (f : {hom CS; a , b}), U1 # f = f :> (a -> b)).
+  /\ (forall (a b : CS) (f : {hom CS; a , b}), U1 # f = f :> (a -> b)).
 Proof. by []. Qed.
 End free_semiCompSemiLattConvType_functor.
 
@@ -495,18 +487,15 @@ Local Open Scope classical_set_scope.
 Local Open Scope convex_scope.
 Local Notation F1 := free_semiCompSemiLattConvType.
 Local Notation U1 := forget_semiCompSemiLattConvType.
-Local Notation CV := convType_category.
-Local Notation CS := semiCompSemiLattConvType_category.
+Implicit Types L : semiCompSemiLattConvType.
 
-Let eps1'' {L : semiCompSemiLattConvType}
-  (X : necset_semiCompSemiLattConvType L) : L := |_| X.
+Let eps1'' L := (fun X : {necset L} => |_| X).
 
 Lemma eps1''_biglubmorph L : biglubmorph (@eps1'' L).
 Proof.
 move=> F.
-rewrite /eps1''.
-transitivity (|_| (biglub @` ((fun X : necset_semiCompSemiLattType L => (X : neset _)) @` F))%:ne); last first.
-- congr (|_| _).
+transitivity (|_| (biglub @` ((fun X : {necset L} => (X : neset _)) @` F))%:ne); last first.
+  congr (|_| _).
   apply/neset_ext; rewrite eqEsubset; split => x [] x0 Fx0 <-.
   + by case: Fx0 => x1 Fx1 <-; exists x1.
   + by exists x0 => // ; exists x0.
@@ -517,8 +506,7 @@ Qed.
 
 Lemma eps1''_affine L : affine (@eps1'' L).
 Proof.
-move=> X Y p; rewrite /eps1''.
-rewrite -biglub_conv_setD.
+move=> X Y p; rewrite -biglub_conv_setD.
 congr (|_| _%:ne); apply/neset_ext => /=.
 rewrite conv_setE necset_convType.convE eqEsubset; split=> u.
 - case=> x [] y [] xX [] yY ->.
@@ -529,7 +517,7 @@ rewrite conv_setE necset_convType.convE eqEsubset; split=> u.
 Qed.
 
 Let eps1' : F1 \O U1 ~~> FId :=
-  fun L => @Hom.Pack CS _ _ _ (@eps1'' L)
+  fun L => HomPack ((F1 \O U1) L) (FId L) (@eps1'' L)
     (BiglubAffine.Class (@eps1''_affine L) (@eps1''_biglubmorph L)).
 
 Lemma eps1'_natural : naturality _ _ eps1'.
@@ -539,8 +527,7 @@ rewrite biglub_morph; congr (|_| _).
 by rewrite free_semiCompSemiLattConvType_morE.
 Qed.
 
-Definition eps1 : F1 \O U1 ~> FId := locked
-  (Natural.Pack (Natural.Mixin eps1'_natural)).
+Definition eps1 : F1 \O U1 ~> FId := locked (Natural eps1'_natural).
 
 Lemma eps1E (L : semiCompSemiLattConvType) :
   eps1 L = (fun X => |_| X) :> (_ -> _).
@@ -556,23 +543,24 @@ move=> p a b /=; apply/necset_ext; rewrite eqEsubset; split=> x /=.
 Qed.
 
 Let eta1' : FId ~~> U1 \O F1 :=
-  fun C => @Hom.Pack CV _ _ _ (@necset1 C) (@necset1_affine C).
+  fun C => HomPack (FId C) ((U1 \O F1) C) (@necset1 C) (@necset1_affine C).
 
 Lemma eta1'_natural : naturality _ _ eta1'.
 Proof.
-move=> a b h; rewrite funeqE=> x; apply necset_ext => /=.
-by rewrite /eta1' /= /id_f free_semiCompSemiLattConvType_morE'/= image_set1.
+move=> a b h; rewrite funeqE => x; apply necset_ext => /=.
+by rewrite free_semiCompSemiLattConvType_morE' /= image_set1.
 Qed.
 
-Definition eta1 : FId ~> U1 \O F1 := locked
-  (Natural.Pack (Natural.Mixin eta1'_natural)).
+Definition eta1 : FId ~> U1 \O F1 := locked (Natural eta1'_natural).
 
 Lemma eta1E (C : convType) : eta1 C = @necset1 _ :> (_ -> _).
 Proof. by rewrite /eta1; unlock. Qed.
 
 Import comps_notation.
+
 Lemma necset1E (T : convType) (t : T) : necset1 t = [set t] :> set T.
 Proof. by []. Qed.
+
 Lemma triL1 : TriangularLaws.left eta1 eps1.
 Proof.
 move=> c; apply funext => x /=; apply/necset_ext => /=.
@@ -582,8 +570,10 @@ rewrite eqEsubset eta1E; split=> a.
 - by case=> y [] b xb <-; rewrite necset1E => ->.
 - by move=> xa; exists (necset1 a); [exists a | rewrite necset1E].
 Qed.
+
 Lemma triR1 : TriangularLaws.right eta1 eps1.
 Proof. by move=> c; apply funext=> /= x; rewrite eps1E eta1E /= biglub1. Qed.
+
 End eps1_eta1.
 
 Section join1.
@@ -592,11 +582,11 @@ Local Open Scope convex_scope.
 Local Open Scope classical_set_scope.
 Variable C : convType.
 
-Definition join1' (s : necset (necset_convType C)) : {convex_set C} :=
+Definition join1' (s : necset {necset C}) : {convex_set C} :=
   CSet.Pack (CSet.Class
     (hull_is_convex (classical_sets.bigsetU s (fun x => if x \in s then (x : set _) else cset0 _)))).
 
-Lemma join1'_neq0 (s : necset (necset_convType C)) : join1' s != set0 :> set _.
+Lemma join1'_neq0 (s : necset {necset C}) : join1' s != set0 :> set _.
 Proof.
 rewrite hull_eq0 set0P.
 case/set0P: (neset_neq0 s) => y.
@@ -604,11 +594,11 @@ case/set0P: (neset_neq0 y) => x yx sy.
 by exists x; exists y => //; move: sy; rewrite -in_setE => ->.
 Qed.
 
-Definition join1 (s : necset (necset_convType C)) : necset C :=
+Definition join1 (s : necset {necset C}) : necset C :=
   NECSet.Pack (NECSet.Class (CSet.Class (hull_is_convex _))
                             (NESet.Mixin (join1'_neq0 s))).
 
-Lemma eps1_correct (s : necset (necset_convType C)) : @eps1 _ s = join1 s.
+Lemma eps1_correct (s : necset {necset C}) : @eps1 _ s = join1 s.
 Proof.
 rewrite eps1E; apply/necset_ext => /=; congr (hull _).
 rewrite /bigsetU; rewrite funeqE => c; rewrite propeqE; split.
@@ -620,7 +610,6 @@ End join1.
 
 Section P_delta_functor.
 Import category.
-Local Notation CT := Type_category.
 
 Definition P_delta_left :=
   free_semiCompSemiLattConvType \O free_convType \O free_choiceType.
@@ -631,7 +620,7 @@ Definition P_delta_right :=
 (* action on objects *)
 Definition P_delta_acto (T : Type) : Type := P_delta_left T.
 
-Definition P_delta : functor CT CT := P_delta_right \O P_delta_left.
+Definition P_delta : {functor CT -> CT} := P_delta_right \O P_delta_left.
 
 Lemma P_deltaE (A B : Type) (f : {hom A, B}) :
   P_delta # f = P_delta_left # f :> (_ -> _).
@@ -677,23 +666,18 @@ Variable T : Type.
 Variable X : gcm (gcm T).
 Lemma gcm_joinE : Join X = necset_join X.
 Import category.
+Local Open Scope convex_scope.
 apply/necset_ext.
 rewrite /= /Monad_of_category_monad.join /= !HCompId !HIdComp eps1E.
-have-> : (AdjComp.F F0 F1
-                # epsC
-                    (AdjComp.G U0 U1
-                       (necset_semiCompSemiLattConvType
-                          (FSDist_convType (choice_of_Type T)))))%category = idfun :> (_ -> _).
-- by rewrite -[in RHS]functor_id; congr Actm; apply/hom_ext; rewrite epsCE.
-have-> : (F1
-              # eps0
-              (U1
-                 (necset_semiCompSemiLattConvType (FSDist_convType (choice_of_Type T)))))%category =
-         @necset_join.F1join0 _ :> (_ -> _).
-- apply funext=> x; apply necset_ext.
+have -> : (AdjComp.F F0 F1 #
+  epsC (AdjComp.G U0 U1 {necset {dist (choice_of_Type T)}}))%category = idfun :> (_ -> _).
+  by rewrite -[in RHS]functor_id; congr Actm; apply/hom_ext; rewrite epsCE.
+have -> : (F1 # eps0 (U1 {necset {dist (choice_of_Type T)}}))%category =
+        @necset_join.F1join0 _ :> (_ -> _).
+  apply funext=> x; apply necset_ext.
   rewrite /= /necset_join.F1join0' /=.
   rewrite /free_semiCompSemiLattConvType_mor; unlock=> /=.
-  by rewrite eps0E /=.
+  by rewrite eps0E.
 rewrite -(bigcup_image
             _ _ _ _
             (fun x => if x \in necset_join.F1join0 X then NECSet.car x else set0) idfun).

--- a/gcm_model.v
+++ b/gcm_model.v
@@ -376,7 +376,7 @@ Variables (A B : convType) (f : {hom A , B}).
 
 Definition free_semiCompSemiLattConvType_mor' (X : {necset A}) : {necset B} :=
   NECSet.Pack (NECSet.Class
-    (CSet.Class (is_convex_set_image [affine of f] X))
+    (CSet.Mixin (is_convex_set_image [affine of f] X))
     (NESet.Mixin (neset_image_neq0 _ _))).
 
 (* the results of free_semiCompSemiLattConvType_mor are
@@ -407,7 +407,7 @@ Proof.
 rewrite funeqE => b; rewrite propeqE; split.
 - case => a [x Xx xa] <-{b}.
   exists (NECSet.Pack (NECSet.Class
-      (CSet.Class (is_convex_set_image [affine of f] x))
+      (CSet.Mixin (is_convex_set_image [affine of f] x))
       (NESet.Mixin (neset_image_neq0 f x)))) => /=; last by exists a.
   by exists x => //=; exact/necset_ext.
 - by case => b0 [a0 Xa0 <-{b0}] [a a0a <-{b}]; exists a => //; exists a0.
@@ -420,8 +420,7 @@ move=> /= X; apply necset_ext => /=; rewrite funeqE => b.
 by rewrite image_preserves_convex_hull bigsetU_affine.
 Qed.
 
-Definition free_semiCompSemiLattConvType_mor :
-  {hom {necset A}, {necset B}} :=
+Definition free_semiCompSemiLattConvType_mor : {hom {necset A}, {necset B}} :=
   locked (HomPack
     {necset A} {necset B}
     free_semiCompSemiLattConvType_mor'
@@ -583,7 +582,7 @@ Local Open Scope classical_set_scope.
 Variable C : convType.
 
 Definition join1' (s : necset {necset C}) : {convex_set C} :=
-  CSet.Pack (CSet.Class
+  CSet.Pack (CSet.Mixin
     (hull_is_convex (classical_sets.bigsetU s (fun x => if x \in s then (x : set _) else cset0 _)))).
 
 Lemma join1'_neq0 (s : necset {necset C}) : join1' s != set0 :> set _.
@@ -595,7 +594,7 @@ by exists x; exists y => //; move: sy; rewrite -in_setE => ->.
 Qed.
 
 Definition join1 (s : necset {necset C}) : necset C :=
-  NECSet.Pack (NECSet.Class (CSet.Class (hull_is_convex _))
+  NECSet.Pack (NECSet.Class (CSet.Mixin (hull_is_convex _))
                             (NESet.Mixin (join1'_neq0 s))).
 
 Lemma eps1_correct (s : necset {necset C}) : @eps1 _ s = join1 s.

--- a/meta.yml
+++ b/meta.yml
@@ -73,7 +73,7 @@ dependencies:
     [MathComp analysis](https://github.com/math-comp/analysis)
 - opam:
     name: coq-infotheo
-    version: '{ >= "0.3" & < "0.4~"}'
+    version: '{ >= "0.3.1" & < "0.4~"}'
   description: |-
     [Infotheo](https://github.com/affeldt-aist/infotheo)
 - opam:

--- a/proba_lib.v
+++ b/proba_lib.v
@@ -64,7 +64,7 @@ Proof. by []. Qed.
 
 Lemma choice_ext (q p : prob) (M : probMonad) A (m1 m2 : M A) :
   p = q :> R -> m1 <| p |> m2 = m1 <| q |> m2.
-Proof. by move/prob_ext => ->. Qed.
+Proof. by move/val_inj => ->. Qed.
 
 Lemma uniform_cons (M : probMonad) (A : Type) (def : A) h s :
   uniform def (h :: s) = Ret h <| (/ IZR (Z_of_nat (size (h :: s))))%:pr |> uniform def s :> M A.
@@ -94,17 +94,17 @@ Lemma uniform_cat (M : probMonad) (A : Type) (a : A) s t :
 Proof.
 elim: s t => [t m n|s1 s2 IH t m n].
   rewrite cat0s uniform_nil /= [X in _ <| X |> _](_ : _ = 0%:pr) ?choice0 //.
-  by apply prob_ext => /=; rewrite /divRnnm div0R.
+  by apply val_inj; rewrite /= /divRnnm div0R.
 case/boolP : (m.-1 + n == 0)%nat => [{IH}|] m1n0.
   have s20 : s2 = [::] by move: m1n0; rewrite {}/m /=; case: s2.
   have t0 : t = [::] by move: m1n0; rewrite {}/n /= addnC; case: t.
   subst s2 t.
   rewrite cats0 (_ : Prob.mk _ = 1%:pr) ?choice1 //.
-  by apply prob_ext => /=; rewrite /divRnnm div1R invR1.
+  by apply val_inj; rewrite /= /divRnnm div1R invR1.
 rewrite cat_cons uniform_cons uniform_cons.
 set pv := ((/ _)%R).
 set v : prob := @Prob.mk pv _.
-set u := @Prob.mk (INR (size s2) / INR (size s2 + size t))%R (prob_divRnnm _ _).
+set u := @Prob.mk_ (INR (size s2) / INR (size s2 + size t))%R (prob_divRnnm _ _).
 rewrite -[RHS](choiceA v u).
   by rewrite -IH.
 split.
@@ -158,7 +158,7 @@ move/(_ isT) => IH _.
 rewrite compE [in RHS]compE [in LHS]uniform_cons [in RHS]uniform_cons.
 set p := (@Prob.mk (/ IZR (Z.of_nat (size _)))%R _ in X in _ = X).
 rewrite (_ : @Prob.mk (/ _)%R _ = p); last first.
-  by apply prob_ext => /=; rewrite size_map.
+  by apply val_inj; rewrite /= size_map.
 move: IH; rewrite 2!compE => ->.
 by rewrite [in RHS]fmapE prob_bindDl bindretf fmapE; congr Choice.
 Qed.
@@ -188,12 +188,11 @@ pose n := size y.
 pose l := size (cp xxs y).
 rewrite (_ : size _ = n); last by rewrite size_map.
 rewrite (_ : Prob.mk _ = probdivRnnm n l); last first.
-  rewrite -/(cp _ _) -/l.
-  by apply prob_ext => /=.
+  by rewrite -/(cp _ _) -/l; exact/val_inj.
 pose m := size xxs.
 have lmn : (l = m * n)%nat by rewrite /l /m /n size_allpairs.
-rewrite (_ : probdivRnnm _ _ = @Prob.mk (/ (INR (1 + m))) (prob_invn _))%R; last first.
-  apply prob_ext => /=.
+rewrite (_ : probdivRnnm _ _ = @Prob.mk_ (/ (INR (1 + m))) (prob_invn _))%R; last first.
+  apply val_inj => /=.
   rewrite lmn /divRnnm -mulSn mult_INR {1}/Rdiv Rinv_mult_distr; last 2 first.
     by rewrite INR_eq0.
     by rewrite INR_eq0; apply/eqP; rewrite -lt0n.
@@ -206,7 +205,7 @@ rewrite {1}/cp [in X in uniform _ X]/= cats0 => ->.
 rewrite -prob_bindDl.
 rewrite [in RHS]/mpair uniform_cat.
 rewrite [in RHS](_ : Prob.mk _ = probinvn m) //.
-by apply prob_ext => /=; rewrite /divRnnm div1R.
+by apply val_inj; rewrite /= /divRnnm div1R.
 Qed.
 
 Section altci_semilatttype.
@@ -295,7 +294,7 @@ split.
 - rewrite leR_pdivr_mulr ?mul1R; last exact: addR_gt0wl.
   by rewrite addRC -leR_subl_addr subRR.
 Qed.
-Definition Prob_invp := Prob.mk prob_invp.
+Definition Prob_invp := Prob.mk_ prob_invp.
 
 Lemma two_coinsE : two_coins = two_coins'.
 Proof.
@@ -343,7 +342,7 @@ by rewrite mulRAC -mulRA mulRV // mulR1 mul1R leR_add2l; apply/Ropp_le_contravar
 Qed.
 
 Definition magnified_weight (p q r : prob) (H : p < q < r) : prob :=
-  Prob.mk (magnified_weight_proof H).
+  Prob.mk_ (magnified_weight_proof H).
 
 Local Notation m := magnified_weight.
 Local Notation "x +' y" := (addpt x y) (at level 50).
@@ -439,17 +438,17 @@ rewrite choicemm.
 rewrite [in LHS](choiceA (/ 4)%:pr (/ 3).~%:pr (/ 3)%:pr (/ 4).~%:pr); last first.
   by rewrite 4!probpK /= /onem; split; field.
 rewrite choicemm.
-rewrite [in LHS](choiceA (/ 7)%:pr (/ 6)%:pr (/ 2)%:pr (@Prob.mk (2/7) H27)); last first.
+rewrite [in LHS](choiceA (/ 7)%:pr (/ 6)%:pr (/ 2)%:pr (@Prob.mk_ (2/7) H27)); last first.
   by rewrite 4!probpK /= /onem; split; field.
 rewrite choicemm.
-rewrite [in LHS](choiceA (/ 8)%:pr (@Prob.mk (2/7) H27) (@Prob.mk (7/21) H721) (@Prob.mk (21/56) H2156)); last first.
-  by rewrite 4!probpK /= /onem; split; field.
+rewrite [in LHS](choiceA (/ 8)%:pr (@Prob.mk_ (2/7) H27) (@Prob.mk_ (7/21) H721) (@Prob.mk_ (21/56) H2156)); last first.
+  by rewrite 3!probpK /= /onem; split; field.
 rewrite (choiceC (/ 4).~%:pr).
-rewrite [in LHS](choiceA (/ 5)%:pr (probcplt (/ 4).~%:pr) (/ 2)%:pr (@Prob.mk (2/5) H25)); last first.
+rewrite [in LHS](choiceA (/ 5)%:pr (probcplt (/ 4).~%:pr) (/ 2)%:pr (@Prob.mk_ (2/5) H25)); last first.
   by rewrite 3!probpK /= /onem; split; field.
 rewrite 2!choicemm.
-rewrite (choiceC (@Prob.mk (2/5) H25)).
-rewrite [in LHS](choiceA (@Prob.mk (21/56) H2156) (probcplt (Prob.mk H25)) (/ 2)%:pr (/ 4).~%:pr); last first.
+rewrite (choiceC (@Prob.mk_ (2/5) H25)).
+rewrite [in LHS](choiceA (@Prob.mk_ (21/56) H2156) (probcplt (Prob.mk_ H25)) (/ 2)%:pr (/ 4).~%:pr); last first.
   by rewrite 3!probpK /= /onem; split; field.
 rewrite choicemm.
 rewrite (choiceC (/ 4).~%:pr).
@@ -464,15 +463,14 @@ Definition uFFT {M : probMonad} : M bool :=
 Lemma uFFTE (M : probMonad) : uFFT = bcoin (/ 3)%:pr :> M _.
 Proof.
 rewrite /uFFT /bcoin uniform_cons.
-rewrite (_ : _%:pr = (/ 3)%:pr)%R; last exact/prob_ext.
+rewrite (_ : _%:pr = (/ 3)%:pr)%R; last exact/val_inj.
 rewrite uniform_cons.
-rewrite [in X in _ <| _ |> X](_ : _%:pr = (/ 2)%:pr)%R; last first.
-  exact/prob_ext.
+rewrite [in X in _ <| _ |> X](_ : _%:pr = (/ 2)%:pr)%R; last exact/val_inj.
 rewrite uniform_singl //=.
 rewrite (choiceA _ _ (/ 2)%:pr (/ 3).~%:pr); last first.
   by rewrite /= /onem; split; field.
 rewrite choicemm choiceC; congr (Ret true <| _ |> Ret false).
-by apply prob_ext => /=; rewrite onemK.
+by apply val_inj; rewrite /= onemK.
 Qed.
 
 Definition uTTF {M : probMonad} : M bool :=
@@ -481,9 +479,9 @@ Definition uTTF {M : probMonad} : M bool :=
 Lemma uTTFE (M : probMonad) : uTTF = bcoin (/ 3).~%:pr :> M _.
 Proof.
 rewrite /uTTF /bcoin uniform_cons.
-rewrite (_ : _%:pr = (/ 3)%:pr)%R; last exact: prob_ext.
+rewrite (_ : _%:pr = (/ 3)%:pr)%R; last exact/val_inj.
 rewrite uniform_cons.
-rewrite [in X in _ <| _ |> X](_ : _%:pr = (/ 2)%:pr)%R; last exact/prob_ext.
+rewrite [in X in _ <| _ |> X](_ : _%:pr = (/ 2)%:pr)%R; last exact/val_inj.
 rewrite uniform_singl //=.
 rewrite (choiceA _ _ (/ 2)%:pr (/ 3).~%:pr) ?choicemm //.
 by rewrite /= /onem; split; field.
@@ -500,7 +498,7 @@ elim: s => [//|h t IH _ H].
 rewrite uniform_cons.
 case/boolP : (t == [::]) => [/eqP -> {IH}|t0].
   rewrite uniform_nil.
-  rewrite (_ : _%:pr = 1%:pr); last by apply prob_ext => /=; rewrite Rinv_1.
+  rewrite (_ : _%:pr = 1%:pr); last by apply val_inj; rewrite /= Rinv_1.
   rewrite choice1.
   rewrite 2!bindretf ifF //; apply/negbTE/H; by rewrite mem_head.
 rewrite 2!prob_bindDl; congr (_ <| _ |> _).
@@ -512,7 +510,7 @@ Lemma choice_halfC A (M : probMonad) (a b : M A) :
   a <| (/ 2)%:pr |> b = b <| (/ 2)%:pr |> a.
 Proof.
 rewrite choiceC (_ : (_.~)%:pr = (/ 2)%:pr) //.
-by apply prob_ext => /=; rewrite /onem; lra.
+by apply val_inj; rewrite /= /onem; lra.
 Qed.
 
 Lemma choice_halfACA A (M : probMonad) (a b c d : M A) :

--- a/proba_monad_model.v
+++ b/proba_monad_model.v
@@ -3,7 +3,7 @@
 From mathcomp Require Import all_ssreflect.
 From mathcomp Require boolp.
 From infotheo Require Import Reals_ext ssr_ext fsdist.
-From infotheo Require convex.
+From infotheo Require Import convex.
 Require Import monae_lib hierarchy monad_lib proba_lib.
 
 (******************************************************************************)
@@ -17,6 +17,8 @@ Notation choice_of_Type := convex.choice_of_Type.
 
 Module MonadProbModel.
 Local Obligation Tactic := idtac.
+
+Set Printing All.
 
 Definition ret' : forall A, A -> {dist (choice_of_Type A)} :=
   fun A a => FSDist1.d (a : choice_of_Type A).


### PR DESCRIPTION
NB: based on infotheo's ~~master~~ 0.3.1 ~~!~~

- definitions convType_category_mixin and semiCompSemiLattConvType_category_mixin
  are more uniform
- hom_affine_function move earlier in the file as hom_affine to avoid case analysis
  + declared as Canonical to enjoy [affine of _] notation
- similarly, hom_biglubmorph declared as Canonical for the generic lemma biglub_morph
  to be usable
  + instead of the ill-named apply_affine
- remove eps0'', eta1''
  + they may have been here to be uniform but they are really just redefinitions
  + more generally trying to reduce the number of identifiers and lemmas
    ending with ' or '' by turning blah''/blah' definitions as Let
    and favoring blahE lemmas (instead of blah''E/blah'E)
- minor improvements coming partly from a new infotheo branch
  + is_convex_set_image' replaced with is_convex_set_image
  + generalizations from necset_convType to necset

@t6s 