### PR TITLE
moving generic lemmas out of example_array.v

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ This library has been applied to other formalizations:
 - [category.v](./category.v): formalization of categories (generalization of ~hierarchy.v~)
 - [fail_lib.v](./fail_lib.v): lemmas about fail monad and related monads
 - [state_lib.v](./state_lib.v): lemmas about state-related monads
+- [array_lib.v](./array_lib.v): lemmas about the array monad
 - [trace_lib.v](./trace_lib.v): lemmas about about the state-trace monad
 - [proba_lib.v](./proba_lib.v): about the probability monad
 - [monad_composition.v](./monad_composition.v): composing monads

--- a/_CoqProject
+++ b/_CoqProject
@@ -10,6 +10,7 @@ hierarchy.v
 monad_lib.v
 fail_lib.v
 state_lib.v
+array_lib.v
 trace_lib.v
 proba_lib.v
 monad_composition.v

--- a/array_lib.v
+++ b/array_lib.v
@@ -1,0 +1,186 @@
+(* monae: Monadic equational reasoning in Coq                                 *)
+(* Copyright (C) 2020 monae authors, license: LGPL-2.1-or-later               *)
+From mathcomp Require Import all_ssreflect.
+From mathcomp Require boolp.
+Require Import monae_lib.
+From HB Require Import structures.
+Require Import hierarchy monad_lib fail_lib.
+From infotheo Require Import ssrZ.
+Require Import ZArith.
+
+(******************************************************************************)
+(*                Definitions and lemmas about the array monad                *)
+(*                                                                            *)
+(*           aswap i j == swap the cells at addresses i and j; this is a      *)
+(*                        computation of type (M unit)                        *)
+(*       writeList i s == write the list s at address i; this is a            *)
+(*                        computation of type (M unit)                        *)
+(*          writeL i s := writeList i s >> Ret (size s)                       *)
+(*    write2L i (s, t) := writeList i (s ++ t) >> Ret (size s, size t)        *)
+(* write3L i (s, t, u) := writeList i (s ++ t ++ u) >>                        *)
+(*                        Ret (size s, size t, size u)                        *)
+(*        readList i n == read the list of values of size n starting at       *)
+(*                        address i; it is a computation of type (M (seq E))  *)
+(*                        where E is the type of stored elements              *)
+(*                                                                            *)
+(******************************************************************************)
+
+Local Open Scope monae_scope.
+Local Open Scope zarith_ext_scope.
+
+Section marray.
+Context {d : unit} {E : porderType d} {M : plusArrayMonad E Z_eqType}.
+Implicit Type i j : Z.
+
+Definition aswap i j : M unit :=
+  aget i >>= (fun x => aget j >>= (fun y => aput i y >> aput j x)).
+
+Lemma aswapxx i : aswap i i = skip.
+Proof.
+rewrite /aswap agetget.
+under eq_bind do rewrite aputput.
+by rewrite agetputskip.
+Qed.
+
+Fixpoint writeList i (s : seq E) : M unit :=
+  if s isn't x :: xs then Ret tt else aput i x >> writeList (i + 1) xs.
+
+Lemma aput_writeListC i j (x : E) (xs : seq E) : (i < j)%Z ->
+  aput i x >> writeList j xs = writeList j xs >> aput i x.
+Proof.
+elim: xs i j => [|h tl ih] i j ij.
+  by rewrite bindretf bindmskip.
+rewrite /= -bindA aputC; last by left; apply/eqP/ltZ_eqF.
+rewrite !bindA; bind_ext => -[].
+by rewrite ih// ltZadd1; apply/ltZW.
+Qed.
+
+Lemma writeListC i j (ys zs : seq E) : (i + (size ys)%:Z <= j)%Z ->
+  writeList i ys >> writeList j zs = writeList j zs >> writeList i ys.
+Proof.
+elim: ys zs i j => [|h t ih] zs i j hyp.
+  by rewrite bindretf bindmskip.
+rewrite /= aput_writeListC; last by rewrite ltZadd1; exact: leZZ.
+rewrite bindA aput_writeListC; last first.
+  apply: (ltZ_leZ_trans _ hyp).
+  by apply: ltZ_addr => //; exact: leZZ.
+rewrite -!bindA ih => [//|].
+by rewrite /= natZS -add1Z addZA in hyp.
+Qed.
+
+Lemma aput_writeListCR i j (x : E) (xs : seq E) : (j + (size xs)%:Z <= i)%Z ->
+  aput i x >> writeList j xs = writeList j xs >> aput i x.
+Proof.
+move=> ?.
+have -> : aput i x = writeList i [:: x].
+  by rewrite /= bindmskip.
+by rewrite writeListC.
+Qed.
+
+Lemma writeList_cons i (x : E) (xs : seq E) :
+  writeList i (x :: xs) = aput i x >> writeList (i + 1) xs.
+Proof. by []. Qed.
+
+Lemma writeList_cat i (s t : seq E) :
+  writeList i (s ++ t) = writeList i s >> writeList (i + (size s)%:Z) t.
+Proof.
+elim: s i => [|h tl ih] i /=; first by rewrite bindretf addZ0.
+by rewrite ih bindA -addZA add1Z natZS.
+Qed.
+
+Lemma writeList_rcons i (x : E) (xs : seq E) :
+  writeList i (rcons xs x) = writeList i xs >> aput (i + (size xs)%:Z)%Z x.
+Proof. by rewrite -cats1 writeList_cat /= -bindA bindmskip. Qed.
+
+Definition writeL i (s : seq E) := writeList i s >> Ret (size s).
+
+Definition write2L i '(s, t) := writeList i (s ++ t) >> Ret (size s, size t).
+
+Definition write3L i '(s, t, u) :=
+  writeList i (s ++ t ++ u) >> Ret (size s, size t, size u).
+
+Lemma write_read i p : aput i p >> aget i = aput i p >> Ret p :> M _.
+Proof. by rewrite -[RHS]aputget bindmret. Qed.
+
+Lemma write_readC i j p : i != j ->
+  aput i p >> aget j = aget j >>= (fun v => aput i p >> Ret v) :> M _.
+Proof. by move => ?; rewrite -aputgetC // bindmret. Qed.
+
+(* see postulate introduce-read in the Agda code *)
+Lemma writeListRet i (p : E) (s : seq E) :
+  writeList i (p :: s) >> Ret p = writeList i (p :: s) >> aget i.
+Proof.
+rewrite /=.
+elim/last_ind: s p i => [|h t ih] /= p i.
+  by rewrite bindmskip write_read.
+transitivity ((aput i p >> writeList (i + 1) h >>
+               aput (i + 1 + (size h)%:Z)%Z t) >> aget i); last first.
+  by rewrite writeList_rcons !bindA.
+rewrite ![RHS]bindA write_readC; last first.
+  apply/eqP/gtZ_eqF; rewrite addZC; apply/ltZ_addl; first exact/leZ0n.
+  exact/ltZadd1/leZZ.
+rewrite -2![RHS]bindA -ih [RHS]bindA.
+transitivity ((aput i p >> writeList (i + 1) h >>
+               aput (i + 1 + (size h)%:Z)%Z t) >> Ret p).
+  by rewrite writeList_rcons !bindA.
+rewrite !bindA; bind_ext => -[].
+by under [in RHS]eq_bind do rewrite bindretf.
+Qed.
+
+Lemma writeList_aswap i x h (t : seq E) :
+  writeList i (rcons (h :: t) x) =
+  writeList i (rcons (x :: t) h) >> aswap i (i + (size (rcons t h))%:Z).
+Proof.
+rewrite /aswap -!bindA writeList_rcons /=.
+rewrite aput_writeListC; last by apply/ltZ_addr => //; exact: leZZ.
+rewrite bindA.
+rewrite aput_writeListC; last by apply/ltZ_addr => //; exact: leZZ.
+rewrite writeList_rcons !bindA; bind_ext => -[].
+under [RHS] eq_bind do rewrite -bindA.
+rewrite aputget -bindA size_rcons -addZA natZS -add1Z.
+under [RHS] eq_bind do rewrite -!bindA.
+rewrite aputgetC; last first.
+  apply/eqP/ltZ_eqF; rewrite addZA addZC; apply/ltZ_addl.
+    exact/leZ0n.
+  by apply/ltZ_addr => //; exact: leZZ.
+rewrite -!bindA aputget aputput aputC; last by right.
+by rewrite bindA aputput.
+Qed.
+
+Lemma aput_writeList_rcons i x h (t : seq E) :
+  aput i x >> writeList (i + 1) (rcons t h) =
+  aput i h >>
+      ((writeList (i + 1) t >> aput (i + 1 + (size t)%:Z)%Z x) >>
+        aswap i (i + (size t).+1%:Z)).
+Proof.
+rewrite /aswap -!bindA writeList_rcons -bindA.
+rewrite aput_writeListC; last by rewrite ltZadd1; exact: leZZ.
+rewrite aput_writeListC; last by rewrite ltZadd1; exact: leZZ.
+rewrite !bindA; bind_ext => -[].
+under [RHS] eq_bind do rewrite -bindA.
+rewrite aputgetC; last first.
+  apply/eqP/gtZ_eqF; rewrite addZC; apply/ltZ_addl; first exact: leZ0n.
+  by apply/ltZ_addr => //; exact: leZZ.
+rewrite -bindA -addZA natZS -add1Z aputget.
+under [RHS] eq_bind do rewrite -!bindA.
+rewrite aputget aputC; last by right.
+by rewrite -!bindA aputput bindA aputput.
+Qed.
+
+(* TODO: rename *)
+(* NB: used in the proof of writeList_ipartl *)
+Lemma introduce_read_sub i (p : E) (xs : seq E) (f : E -> M (nat * nat)%type):
+  writeList i (p :: xs) >> Ret p >> f p =
+  writeList i (p :: xs) >> aget i >>= f.
+Proof.
+rewrite writeListRet 2!bindA /=.
+rewrite aput_writeListC; last by apply/ltZ_addr => //; exact: leZZ.
+rewrite 2!bindA.
+under [LHS] eq_bind do rewrite -bindA aputget.
+by under [RHS] eq_bind do rewrite -bindA aputget.
+Qed.
+
+Fixpoint readList i (n : nat) : M (seq E) :=
+  if n isn't k.+1 then Ret [::] else liftM2 cons (aget i) (readList (i + 1) k).
+
+End marray.

--- a/example_nqueens.v
+++ b/example_nqueens.v
@@ -528,7 +528,7 @@ Lemma queensBodyE : queensBody M =
 Proof.
 rewrite /queensBody boolp.funeqE => -[|h t].
 - rewrite /= permsE /= hyloME ?bindretf //; exact: decr_size_select.
-- by rewrite [h :: t]lock -theorem51 /kleisli /= join_fmap perms_mu_perm.
+- by rewrite [h :: t]lock -theorem51 /kleisli /= join_fmap perms_uperm.
 Qed.
 
 Local Open Scope mprog.

--- a/example_quicksort.v
+++ b/example_quicksort.v
@@ -380,7 +380,7 @@ apply: (@refin_trans _ _ _); last first.
   exact: (refin_guard_le _ _ _ t).
 apply: (@refin_trans _ _ _); last first.
   apply: refin_bindl => x1.
-  exact: guard_neg.
+  exact: refin_if_guard.
 under eq_bind do rewrite -bind_if.
 apply: (@refin_trans _ _ (
   (do a <- splits xs;

--- a/hierarchy.v
+++ b/hierarchy.v
@@ -675,39 +675,47 @@ End fmap_and_join.
 
 Section kleisli.
 Variable M : monad.
+Implicit Types A B C D : UU0.
 
-Definition kleisli (A B C : UU0) (m : B -> M C) (n : A -> M B) : A -> M C :=
+Definition kleisli A B C (m : B -> M C) (n : A -> M B) : A -> M C :=
   Join \o (M # m) \o n.
 Local Notation "m <=< n" := (kleisli m n).
 Local Notation "m >=> n" := (kleisli n m).
 
-Lemma kleisli_def (A B C : UU0) (g : B -> M C) (f : A -> M B) :
+Lemma kleisli_def A B C (g : B -> M C) (f : A -> M B) :
   (f >=> g) = Join \o (M # g) \o f.
 Proof. by []. Qed.
 
-Lemma kleisliE (A B C : UU0) (g : B -> M C) (f : A -> M B) (a : A) :
+Lemma kleisliE A B C (g : B -> M C) (f : A -> M B) (a : A) :
   (f >=> g) a = (f a) >>= g.
 Proof. by rewrite /kleisli /= join_fmap. Qed.
 
-Lemma bind_kleisli (A B C : UU0) m (f : A -> M B) (g : B -> M C) :
+Lemma bind_kleisli A B C m (f : A -> M B) (g : B -> M C) :
   m >>= (f >=> g) = (m >>= f) >>= g.
 Proof. by rewrite bindA; bind_ext => a; rewrite /kleisli !compE join_fmap. Qed.
 
-Lemma ret_kleisli (A B : UU0) (k : A -> M B) : Ret >=> k = k.
+Lemma ret_kleisli A B (k : A -> M B) : Ret >=> k = k.
 Proof. by rewrite /kleisli -compA (natural ret) FIdf compA joinretM. Qed.
 
 Local Open Scope mprog.
-Lemma fcomp_kleisli (A B C D : UU0) (f : A -> B) (g : C -> M A) (h : D -> M C) :
+Lemma fcomp_kleisli A B C D (f : A -> B) (g : C -> M A) (h : D -> M C) :
   f (o) (g <=< h) = (f (o) g) <=< h.
 Proof.
 rewrite /kleisli 2!fcomp_def 2!(compA (fmap f)) natural [in RHS]functor_o.
 by rewrite -compA.
 Qed.
 
-Lemma kleisli_fcomp (A B C : UU0) (f : A -> M B) (g : B -> A) (h : C -> M B) :
+Lemma kleisli_fcomp A B C (f : A -> M B) (g : B -> A) (h : C -> M B) :
   ((f \o g) <=< h) = f <=< (g (o) h).
 Proof. by rewrite /kleisli fcomp_def functor_o 2!compA. Qed.
 Local Close Scope mprog.
+
+Lemma kleisliA A B C D (f : A -> M B) (g : B -> M C) (h : C -> M D) :
+  f >=> g >=> h = f >=> (g >=> h).
+Proof.
+apply: fun_ext_dep => a; rewrite !kleisliE bindA.
+by under [in RHS]eq_bind do rewrite kleisliE.
+Qed.
 
 End kleisli.
 Notation "m <=< n" := (kleisli m n) : monae_scope.

--- a/impredicative_set/ihierarchy.v
+++ b/impredicative_set/ihierarchy.v
@@ -61,6 +61,7 @@ From HB Require Import structures.
 (*  failStateReifyMonad == stateReify + fail                                  *)
 (*     nondetStateMonad == backtrackable state                                *)
 (*           arrayMonad == array monad                                        *)
+(*      plusArrayMonad  == plus monad + array monad                           *)
 (*                                                                            *)
 (* Trace monads:                                                              *)
 (*            traceMonad == trace monad                                       *)
@@ -663,39 +664,47 @@ End fmap_and_join.
 
 Section kleisli.
 Variable M : monad.
+Implicit Types A B C D : UU0.
 
-Definition kleisli (A B C : UU0) (m : B -> M C) (n : A -> M B) : A -> M C :=
+Definition kleisli A B C (m : B -> M C) (n : A -> M B) : A -> M C :=
   Join \o (M # m) \o n.
 Local Notation "m <=< n" := (kleisli m n).
 Local Notation "m >=> n" := (kleisli n m).
 
-Lemma kleisli_def (A B C : UU0) (g : B -> M C) (f : A -> M B) :
+Lemma kleisli_def A B C (g : B -> M C) (f : A -> M B) :
   (f >=> g) = Join \o (M # g) \o f.
 Proof. by []. Qed.
 
-Lemma kleisliE (A B C : UU0) (g : B -> M C) (f : A -> M B) (a : A) :
+Lemma kleisliE A B C (g : B -> M C) (f : A -> M B) (a : A) :
   (f >=> g) a = (f a) >>= g.
 Proof. by rewrite /kleisli /= join_fmap. Qed.
 
-Lemma bind_kleisli (A B C : UU0) m (f : A -> M B) (g : B -> M C) :
+Lemma bind_kleisli A B C m (f : A -> M B) (g : B -> M C) :
   m >>= (f >=> g) = (m >>= f) >>= g.
 Proof. by rewrite bindA; bind_ext => a; rewrite /kleisli !compE join_fmap. Qed.
 
-Lemma ret_kleisli (A B : UU0) (k : A -> M B) : Ret >=> k = k.
+Lemma ret_kleisli A B (k : A -> M B) : Ret >=> k = k.
 Proof. by rewrite /kleisli -compA (natural ret) FIdf compA joinretM. Qed.
 
 Local Open Scope mprog.
-Lemma fcomp_kleisli (A B C D : UU0) (f : A -> B) (g : C -> M A) (h : D -> M C) :
+Lemma fcomp_kleisli A B C D (f : A -> B) (g : C -> M A) (h : D -> M C) :
   f (o) (g <=< h) = (f (o) g) <=< h.
 Proof.
 rewrite /kleisli 2!fcomp_def 2!(compA (fmap f)) natural [in RHS]functor_o.
 by rewrite -compA.
 Qed.
 
-Lemma kleisli_fcomp (A B C : UU0) (f : A -> M B) (g : B -> A) (h : C -> M B) :
+Lemma kleisli_fcomp A B C (f : A -> M B) (g : B -> A) (h : C -> M B) :
   ((f \o g) <=< h) = f <=< (g (o) h).
 Proof. by rewrite /kleisli fcomp_def functor_o 2!compA. Qed.
 Local Close Scope mprog.
+
+Lemma kleisliA A B C D (f : A -> M B) (g : B -> M C) (h : C -> M D) :
+  f >=> g >=> h = f >=> (g >=> h).
+Proof.
+apply: fun_ext_dep => a; rewrite !kleisliE bindA.
+by under [in RHS]eq_bind do rewrite kleisliE.
+Qed.
 
 End kleisli.
 Notation "m <=< n" := (kleisli m n) : monae_scope.

--- a/meta.yml
+++ b/meta.yml
@@ -180,6 +180,7 @@ documentation: |-
   - [category.v](./category.v): formalization of categories (generalization of ~hierarchy.v~)
   - [fail_lib.v](./fail_lib.v): lemmas about fail monad and related monads
   - [state_lib.v](./state_lib.v): lemmas about state-related monads
+  - [array_lib.v](./array_lib.v): lemmas about the array monad
   - [trace_lib.v](./trace_lib.v): lemmas about about the state-trace monad
   - [proba_lib.v](./proba_lib.v): about the probability monad
   - [monad_composition.v](./monad_composition.v): composing monads


### PR DESCRIPTION
- add array_lib.v
- renamings to avoid conflicts
  + swap -> aswap
  + mu_perm -> uperm
  + perm -> iperm
- complete documentation about permutations