### PR TITLE
use HB in category.v and other dependent scripts

### DIFF
--- a/altprob_model.v
+++ b/altprob_model.v
@@ -41,8 +41,8 @@ Proof. by move=> x y z; rewrite /alt lubA. Qed.
 Lemma image_FSDistfmap A B (x : gcm A) (k : choice_of_Type A -> gcm B) :
   FSDistfmap k @` x = (gcm # k) x.
 Proof.
-rewrite /hierarchy.actm /= /actm /category.Monad_of_category_monad.actm /=.
-by rewrite /category.id_f /= /free_semiCompSemiLattConvType_mor /=; unlock.
+rewrite /hierarchy.actm /= /actm !FCompE /category.actm /=.
+by rewrite /free_semiCompSemiLattConvType_mor /=; unlock.
 Qed.
 
 Section funalt_funchoice.
@@ -57,23 +57,15 @@ Local Notation U1 := forget_semiCompSemiLattConvType.
 Lemma FunaltDr (A B : Type) (x y : gcm A) (k : A -> gcm B) :
   (gcm # k) (x [+] y) = (gcm # k) x [+] (gcm # k) y.
 Proof.
-rewrite /hierarchy.actm /=.
-rewrite /Monad_of_category_monad.actm /=.
-case: (free_semiCompSemiLattConvType_mor
-        (free_convType_mor (free_choiceType_mor (hom_Type k))))=> f /= [] af ->.
-rewrite lubE; congr biglub.
-apply neset_ext=> /=.
-by rewrite image_setU !image_set1.
+rewrite /hierarchy.actm /= /Monad_of_category_monad.actm /=.
+by rewrite scsl_hom_is_lubmorph.
 Qed.
 
 Lemma FunpchoiceDr (A B : Type) (x y : gcm A) (k : A -> gcm B) p :
   (gcm # k) (x <|p|> y) = (gcm # k) x <|p|> (gcm # k) y.
 Proof.
-rewrite /hierarchy.actm /=.
-rewrite /Monad_of_category_monad.actm /=.
-case: (free_semiCompSemiLattConvType_mor
-  (free_convType_mor (free_choiceType_mor (hom_Type k))))=> f /= [] + _.
-exact.
+rewrite /hierarchy.actm /= /Monad_of_category_monad.actm /=.
+by rewrite scsl_hom_is_affine.
 Qed.
 End funalt_funchoice.
 
@@ -90,24 +82,12 @@ Local Notation U1 := forget_semiCompSemiLattConvType.
 Lemma affine_F1e0U1PD_alt T (u v : gcm (gcm T)) :
   (F1 # eps0 (U1 (P_delta_left T)))%category (u [+] v) =
   (F1 # eps0 (U1 (P_delta_left T)))%category u [+] (F1 # eps0 (U1 (P_delta_left T)))%category v.
-Proof.
-case: ((F1 # eps0 (U1 (P_delta_left T)))%category)=> f /= [] Haf Hbf.
-rewrite !lubE Hbf.
-congr biglub.
-apply neset_ext=> /=.
-by rewrite image_setU !image_set1.
-Qed.
+Proof. by rewrite scsl_hom_is_lubmorph. Qed.
 
 Lemma affine_e1PD_alt T (x y : el (F1 (FId (U1 (P_delta_left T))))) :
   (eps1 (P_delta_left T)) (x [+] y) =
   (eps1 (P_delta_left T)) x [+] (eps1 (P_delta_left T)) y.
-Proof.
-case: (eps1 (P_delta_left T))=> f /= [] Haf Hbf.
-rewrite !lubE Hbf.
-congr biglub.
-apply neset_ext=> /=.
-by rewrite image_setU !image_set1.
-Qed.
+Proof. by rewrite scsl_hom_is_lubmorph. Qed.
 
 Local Notation F1o := necset_semiCompSemiLattConvType.
 Local Notation F0o := FSDist_convType.
@@ -118,17 +98,8 @@ Local Notation F0m := free_convType_mor.
 Lemma bindaltDl : BindLaws.left_distributive (@hierarchy.bind gcm) alt.
 Proof.
 move=> A B x y k.
-rewrite !hierarchy.bindE /alt FunaltDr.
-suff -> : forall T (u v : gcm (gcm T)),
-  hierarchy.Join (u [+] v : gcm (gcm T)) = hierarchy.Join u [+] hierarchy.Join v by [].
-move=> T u v.
-rewrite /= /join_ /=.
-rewrite HCompId HIdComp /AdjComp.Eps.
-do 3 rewrite VCompE_nat homfunK functor_o !compE.
-rewrite !functor_id HCompId HIdComp.
-rewrite (_ : epsC (U0 (U1 (F1o (F0o (FCo T))))) = [NEq _, _] _) ?hom_ext ?epsCE //.
-rewrite NEqE !functor_id_hom.
-by rewrite affine_F1e0U1PD_alt affine_e1PD_alt.
+rewrite hierarchy.bindE /= /join_ -category.bindE.
+by rewrite scsl_hom_is_lubmorph.
 Qed.
 End bindaltDl.
 
@@ -183,16 +154,14 @@ Lemma affine_F1e0U1PD_conv T (u v : gcm (gcm T)) p :
   ((F1 # eps0 (U1 (P_delta_left T))) (u <|p|> v) =
    (F1 # eps0 (U1 (P_delta_left T))) u <|p|> (F1 # eps0 (U1 (P_delta_left T))) v)%category.
 Proof.
-case: ((F1 # eps0 (U1 (P_delta_left T)))%category)=> f /= [] Haf Hbf.
-by apply: Haf.
+by rewrite scsl_hom_is_affine.
 Qed.
 
 Lemma affine_e1PD_conv T (x y : el (F1 (FId (U1 (P_delta_left T))))) p :
   (eps1 (P_delta_left T)) (x <|p|> y) =
   (eps1 (P_delta_left T)) x <|p|> (eps1 (P_delta_left T)) y.
 Proof.
-rewrite eps1E -biglub_conv_setD; congr (|_| _); apply/neset_ext => /=.
-by rewrite -necset_convType.conv_conv_set.
+by rewrite scsl_hom_is_affine.
 Qed.
 
 Local Notation F1o := necset_semiCompSemiLattConvType.
@@ -204,17 +173,8 @@ Local Notation F0m := free_convType_mor.
 Lemma bindchoiceDl p : BindLaws.left_distributive (@hierarchy.bind gcm) (@choice p).
 Proof.
 move=> A B x y k.
-rewrite !hierarchy.bindE /choice FunpchoiceDr.
-suff -> : forall T (u v : gcm (gcm T)), hierarchy.Join (u <|p|> v : gcm (gcm T)) = hierarchy.Join u <|p|> hierarchy.Join v by [].
-move=> T u v.
-rewrite /= /Monad_of_category_monad.join /=.
-rewrite /join_ /=.
-rewrite HCompId HIdComp /AdjComp.Eps.
-do 3 rewrite VCompE_nat homfunK functor_o !compE.
-rewrite !functor_id HCompId HIdComp.
-rewrite (_ : epsC (U0 (U1 (F1o (F0o (FCo T))))) = [NEq _, _] _) ?hom_ext ?epsCE //.
-rewrite NEqE !functor_id_hom.
-by rewrite affine_F1e0U1PD_conv affine_e1PD_conv.
+rewrite hierarchy.bindE /= /join_ -category.bindE.
+by rewrite scsl_hom_is_affine.
 Qed.
 End bindchoiceDl.
 

--- a/altprob_model.v
+++ b/altprob_model.v
@@ -33,7 +33,7 @@ Local Open Scope latt_scope.
 Local Open Scope monae_scope.
 
 Definition alt A (x y : gcm A) : gcm A := x [+] y.
-Definition choice p A (x y : gcm A) : gcm A := x <| p |> y. (*NB: convex_scope *)
+Definition choice p A (x y : gcm A) : gcm A := x <| p |> y.
 
 Lemma altA A : ssrfun.associative (@alt A).
 Proof. by move=> x y z; rewrite /alt lubA. Qed.
@@ -103,7 +103,7 @@ by rewrite scsl_hom_is_lubmorph.
 Qed.
 End bindaltDl.
 
-HB.instance Definition P_delta_monadAltMixin :=
+HB.instance Definition _ :=
   @isMonadAlt.Build (Monad_of_category_monad.acto Mgcm) alt altA bindaltDl.
 
 Lemma altxx A : idempotent (@alt A).
@@ -111,8 +111,10 @@ Proof. by move=> x; rewrite /= /alt lubxx. Qed.
 Lemma altC A : commutative (@alt A).
 Proof. by move=> a b; rewrite /= /alt /= lubC. Qed.
 
-HB.instance Definition gcmACI :=
+HB.instance Definition _ :=
   @isMonadAltCI.Build (Monad_of_category_monad.acto Mgcm) altxx altC.
+
+Definition gcmACI := [the altCIMonad of gcm].
 
 Lemma choice0 A (x y : gcm A) : x <| 0%:pr |> y = y.
 Proof. by rewrite /choice conv0. Qed.
@@ -153,16 +155,12 @@ Local Notation U1 := forget_semiCompSemiLattConvType.
 Lemma affine_F1e0U1PD_conv T (u v : gcm (gcm T)) p :
   ((F1 # eps0 (U1 (P_delta_left T))) (u <|p|> v) =
    (F1 # eps0 (U1 (P_delta_left T))) u <|p|> (F1 # eps0 (U1 (P_delta_left T))) v)%category.
-Proof.
-by rewrite scsl_hom_is_affine.
-Qed.
+Proof. by rewrite scsl_hom_is_affine. Qed.
 
 Lemma affine_e1PD_conv T (x y : el (F1 (FId (U1 (P_delta_left T))))) p :
   (eps1 (P_delta_left T)) (x <|p|> y) =
   (eps1 (P_delta_left T)) x <|p|> (eps1 (P_delta_left T)) y.
-Proof.
-by rewrite scsl_hom_is_affine.
-Qed.
+Proof. by rewrite scsl_hom_is_affine. Qed.
 
 Local Notation F1o := necset_semiCompSemiLattConvType.
 Local Notation F0o := FSDist_convType.
@@ -178,7 +176,7 @@ by rewrite scsl_hom_is_affine.
 Qed.
 End bindchoiceDl.
 
-HB.instance Definition P_delta_monadProbMixin :=
+HB.instance Definition _ :=
   isMonadProb.Build (Monad_of_category_monad.acto Mgcm)
     choice0 choice1 choiceC choicemm choiceA bindchoiceDl.
 
@@ -186,8 +184,10 @@ Lemma choicealtDr A (p : prob) :
   right_distributive (fun x y : Mgcm A => x <| p |> y) (@alt A).
 Proof. by move=> x y z; rewrite /choice lubDr. Qed.
 
-HB.instance Definition gcmAP :=
+HB.instance Definition _ :=
   @isMonadAltProb.Build (Monad_of_category_monad.acto Mgcm) choicealtDr.
+
+Definition gcmAP := [the altProbMonad of gcm].
 
 End P_delta_altProbMonad.
 

--- a/gcm_model.v
+++ b/gcm_model.v
@@ -655,7 +655,7 @@ apply/necset_ext.
 rewrite /= /join_ /= /Monad_of_category_monad.join /= !HCompId !HIdComp eps1E.
 rewrite functor_o NEqE functor_id compfid.
 rewrite 2!VCompE_nat HCompId HIdComp.
-set E := epsC _; have->: E = (homid0 _) by apply/hom_ext; rewrite epsCE.
+set E := epsC _; have->: E = [hom idfun] by apply/hom_ext; rewrite epsCE.
 rewrite functor_id_hom.
 rewrite !functor_o functor_id !compfid.
 


### PR DESCRIPTION
- use HB instead of hand-crafted packed classes in
   category.v, gcm_model.v, altprob_model.v, category_ext.v  
- remove homid0 and homcomp0 from category.v
- add lemma frefl_transparent in category.v
- rename Module MonadOfAdjoint -> Monad_of_adjoint_functors in category.v
- rename lemmas in gcm_modelv
   hom_affine -> conv_hom_is_affine
   hom_biglubmorph -> scsl_hom_is_biglubmorph
- add lemmas in gcm_model.v
   scsl_hom_is_biglub_affine
   scsl_hom_is_affine
   scsl_hom_is_lubmorph