### PR TITLE
More general bindret

### DIFF
--- a/example_transformer.v
+++ b/example_transformer.v
@@ -189,9 +189,7 @@ Lemma bindLmfail (M := [the monad of option_monad]) S T U (m : stateT S M U)
 Proof.
 rewrite /= /liftS boolp.funeqE => s.
 rewrite except_bindE.
-rewrite {1}bindE /= {1}/join_of_bind /= {1}/bindS /=.
-rewrite {1}bindE /= {1}/join_of_bind /=.
-rewrite /actm /= /MS_map /= /actm /=.
+rewrite {1}bindE /= MS_mapE {1}/bindS /=.
 by case (m s) => // -[].
 Qed.
 

--- a/hierarchy.v
+++ b/hierarchy.v
@@ -459,7 +459,7 @@ Qed.
 
 HB.instance Definition _ :=
   isNatural.Build FId F (ret' : FId ~~> F) ret'_naturality.
-Definition ret := [the FId ~> F of ret'].
+Let ret := [the FId ~> F of ret'].
 
 Let join' : FF ~~> F := fun _ m => bind m idfun.
 Let actm_bind a b c (f : a -> b) m (g : c -> F a) :
@@ -477,7 +477,7 @@ by rewrite bindretf /=.
 Qed.
 
 HB.instance Definition _ := isNatural.Build _ _ _ join'_naturality.
-Definition join := [the FF ~> F of join'].
+Let join := [the FF ~> F of join'].
 
 Let bind_map (A B C : UU0) (f : A -> B) (m : M A) (g : B -> M C) :
   bind ((F # f) m) g = bind m (g \o f).
@@ -492,11 +492,13 @@ Proof.
 rewrite /join /= /hierarchy.actm /= /join' /=.
 by rewrite bind_map.
 Qed.
+
 Lemma joinretM : JoinLaws.left_unit ret join.
 Proof.
 move=> a; rewrite boolp.funeqE => m.
 by rewrite /join /= /join' /= bindretf.
 Qed.
+
 Lemma joinMret : JoinLaws.right_unit ret join.
 Proof.
 move=> a; rewrite boolp.funeqE => m.
@@ -506,6 +508,7 @@ rewrite bindA /=.
 rewrite [X in bind m X](_ : _ = fun x => ret' x) ?bindmret //= boolp.funeqE => ?.
 by rewrite bindretf.
 Qed.
+
 Lemma joinA : JoinLaws.associativity join.
 Proof.
 move => a; rewrite boolp.funeqE => m.
@@ -516,6 +519,7 @@ congr bind.
 rewrite boolp.funeqE => u /=.
 by rewrite bindretf.
 Qed.
+
 HB.instance Definition _ := isMonad.Build M bindE joinretM joinMret joinA.
 HB.end.
 

--- a/hierarchy.v
+++ b/hierarchy.v
@@ -328,7 +328,7 @@ End monad_lemmas.
 
 Module BindLaws.
 Section bindlaws.
-Variable F : functor.
+Variable F : UU0 -> UU0.
 Variable b : forall (A B : UU0), F A -> (A -> F B) -> F B.
 Local Notation "m >>= f" := (b m f).
 

--- a/hierarchy.v
+++ b/hierarchy.v
@@ -429,20 +429,22 @@ HB.factory Record isMonad_ret_bind (F : UU0 -> UU0) := {
 
 HB.builders Context M of isMonad_ret_bind M.
 
-Let actm a b (f : a -> b) m := bind m (@ret' _ \o f).
+Let actm (a b : UU0) (f : a -> b) m := bind m (@ret' _ \o f).
+
 Let actm_id : FunctorLaws.id actm.
 Proof.
 move=> a.
-rewrite /actm boolp.funeqE=> m /=.
+rewrite /actm; apply: boolp.funext=> m /=.
 by rewrite bindmret.
 Qed.
+
 Let actm_comp : FunctorLaws.comp actm.
 Proof.
 move=> a b c g h.
-rewrite /actm boolp.funeqE => m /=.
+rewrite /actm; apply: boolp.funext => m /=.
 rewrite bindA.
 congr bind.
-rewrite boolp.funeqE => u /=.
+apply: boolp.funext => u /=.
 by rewrite bindretf.
 Qed.
 
@@ -453,7 +455,7 @@ Local Notation FF := [the functor of F \o F].
 Let ret'_naturality : naturality FId F ret'.
 Proof.
 move=> a b h.
-rewrite FIdE /hierarchy.actm /= /actm boolp.funeqE => m /=.
+rewrite FIdE /hierarchy.actm /= /actm; apply: boolp.funext => m /=.
 by rewrite bindretf.
 Qed.
 
@@ -462,17 +464,19 @@ HB.instance Definition _ :=
 Let ret := [the FId ~> F of ret'].
 
 Let join' : FF ~~> F := fun _ m => bind m idfun.
-Let actm_bind a b c (f : a -> b) m (g : c -> F a) :
+
+Let actm_bind (a b c : UU0) (f : a -> b) m (g : c -> F a) :
   (actm f) (bind m g) = bind m (actm f \o g).
 Proof. by rewrite /actm bindA. Qed.
+
 Let join'_naturality : naturality FF F join'.
 Proof.
 move=> a b h.
-rewrite /join' /= boolp.funeqE => mm /=.
+rewrite /join' /=; apply: boolp.funext => mm /=.
 rewrite /hierarchy.actm /= /isFunctor.actm /=.
 rewrite actm_bind bindA /=.
 congr bind.
-rewrite boolp.funeqE => m /=.
+apply: boolp.funext => m /=.
 by rewrite bindretf /=.
 Qed.
 
@@ -483,40 +487,40 @@ Let bind_map (A B C : UU0) (f : A -> B) (m : M A) (g : B -> M C) :
   bind ((F # f) m) g = bind m (g \o f).
 Proof.
 rewrite bindA; congr bind.
-by rewrite boolp.funeqE => ?; rewrite bindretf.
+by apply: boolp.funext => ?; rewrite bindretf.
 Qed.
 
-Lemma bindE a b (f : a -> M b) (m : M a) :
+Let bindE (a b : UU0) (f : a -> M b) (m : M a) :
   bind m f = join b ((F # f) m).
 Proof.
 rewrite /join /= /hierarchy.actm /= /join' /=.
 by rewrite bind_map.
 Qed.
 
-Lemma joinretM : JoinLaws.left_unit ret join.
+Let joinretM : JoinLaws.left_unit ret join.
 Proof.
-move=> a; rewrite boolp.funeqE => m.
+move=> a; apply: boolp.funext => m.
 by rewrite /join /= /join' /= bindretf.
 Qed.
 
-Lemma joinMret : JoinLaws.right_unit ret join.
+Let joinMret : JoinLaws.right_unit ret join.
 Proof.
-move=> a; rewrite boolp.funeqE => m.
+move=> a; apply: boolp.funext => m.
 rewrite /join /= /join'.
 rewrite /hierarchy.actm /= /actm /=.
 rewrite bindA /=.
-rewrite [X in bind m X](_ : _ = fun x => ret' x) ?bindmret //= boolp.funeqE => ?.
+rewrite [X in bind m X](_ : _ = fun x => ret' x) ?bindmret //=; apply: boolp.funext => ?.
 by rewrite bindretf.
 Qed.
 
-Lemma joinA : JoinLaws.associativity join.
+Let joinA : JoinLaws.associativity join.
 Proof.
-move => a; rewrite boolp.funeqE => m.
+move => a; apply: boolp.funext => m.
 rewrite /join /= /join'.
 rewrite /hierarchy.actm /= /actm.
 rewrite !bindA.
 congr bind.
-rewrite boolp.funeqE => u /=.
+apply: boolp.funext => u /=.
 by rewrite bindretf.
 Qed.
 

--- a/hierarchy.v
+++ b/hierarchy.v
@@ -420,61 +420,102 @@ Proof. by []. Qed.
 HB.instance Definition _ := isMonad.Build M bindE joinretM joinMret joinA.
 HB.end.
 
-HB.factory Record isMonad_ret_bind (F : UU0 -> UU0) of isFunctor F := {
-  ret : FId ~> [the functor of F] ;
+HB.factory Record isMonad_ret_bind (F : UU0 -> UU0) := {
+  ret' : forall (A : UU0), A -> F A ;
   bind : forall (A B : UU0), F A -> (A -> F B) -> F B ;
-  fmapE : forall (A B : UU0) (f : A -> B) (m : F A),
-    ([the functor of F] # f) m = bind A B m (ret B \o f) ;
-  bindretf : BindLaws.left_neutral bind ret ;
-  bindmret : BindLaws.right_neutral bind ret ;
+  bindretf : BindLaws.left_neutral bind ret' ;
+  bindmret : BindLaws.right_neutral bind ret' ;
   bindA : BindLaws.associative bind }.
 
 HB.builders Context M of isMonad_ret_bind M.
 
+Let actm a b (f : a -> b) m := bind m (@ret' _ \o f).
+Let actm_id : FunctorLaws.id actm.
+Proof.
+move=> a.
+rewrite /actm boolp.funeqE=> m /=.
+by rewrite bindmret.
+Qed.
+Let actm_comp : FunctorLaws.comp actm.
+Proof.
+move=> a b c g h.
+rewrite /actm boolp.funeqE => m /=.
+rewrite bindA.
+congr bind.
+rewrite boolp.funeqE => u /=.
+by rewrite bindretf.
+Qed.
+
+HB.instance Definition _ := isFunctor.Build M actm_id actm_comp.
 Let F := [the functor of M].
+Local Notation FF := [the functor of F \o F].
+
+Let ret'_naturality : naturality FId F ret'.
+Proof.
+move=> a b h.
+rewrite FIdE /hierarchy.actm /= /actm boolp.funeqE => m /=.
+by rewrite bindretf.
+Qed.
+
+HB.instance Definition _ :=
+  isNatural.Build FId F (ret' : FId ~~> F) ret'_naturality.
+Definition ret := [the FId ~> F of ret'].
+
+Let join' : FF ~~> F := fun _ m => bind m idfun.
+Let actm_bind a b c (f : a -> b) m (g : c -> F a) :
+  (actm f) (bind m g) = bind m (actm f \o g).
+Proof. by rewrite /actm bindA. Qed.
+Let join'_naturality : naturality FF F join'.
+Proof.
+move=> a b h.
+rewrite /join' /= boolp.funeqE => mm /=.
+rewrite /hierarchy.actm /= /isFunctor.actm /=.
+rewrite actm_bind bindA /=.
+congr bind.
+rewrite boolp.funeqE => m /=.
+by rewrite bindretf /=.
+Qed.
+
+HB.instance Definition _ := isNatural.Build _ _ _ join'_naturality.
+Definition join := [the FF ~> F of join'].
 
 Let bind_map (A B C : UU0) (f : A -> B) (m : M A) (g : B -> M C) :
   bind ((F # f) m) g = bind m (g \o f).
 Proof.
-rewrite fmapE bindA; congr bind.
-by apply boolp.funext => ?; rewrite bindretf.
+rewrite bindA; congr bind.
+by rewrite boolp.funeqE => ?; rewrite bindretf.
 Qed.
 
-Let naturality_join :
-  naturality [the functor of F \o F] F (join_of_bind bind).
+Lemma bindE a b (f : a -> M b) (m : M a) :
+  bind m f = join b ((F # f) m).
 Proof.
-move=> A B h; apply boolp.funext => mma /=.
-rewrite fmapE /join_of_bind bindA bind_map; congr bind.
-by apply boolp.funext => ma; rewrite compidf fmapE.
+rewrite /join /= /hierarchy.actm /= /join' /=.
+by rewrite bind_map.
 Qed.
-
-HB.instance Definition _ :=
-  isNatural.Build _ _ (join_of_bind bind) naturality_join.
-
-Let bindE (A B : UU0) (f : A -> M B) (m : M A) :
-  bind m f = (join_of_bind bind) B ((F # f) m).
-Proof. by rewrite /join /= /join_of_bind /= bind_map compidf. Qed.
-
-Let join := join_of_bind bind.
-
-Let joinretM : JoinLaws.left_unit ret join.
+Lemma joinretM : JoinLaws.left_unit ret join.
 Proof.
-rewrite /join => A; apply boolp.funext => ma /=.
-by rewrite /join_of_bind /= bindretf.
+move=> a; rewrite boolp.funeqE => m.
+by rewrite /join /= /join' /= bindretf.
 Qed.
-
-Let joinMret : JoinLaws.right_unit ret join.
+Lemma joinMret : JoinLaws.right_unit ret join.
 Proof.
-rewrite /join => A; apply boolp.funext => ma /=.
-by rewrite /join_of_bind bind_map compidf bindmret.
+move=> a; rewrite boolp.funeqE => m.
+rewrite /join /= /join'.
+rewrite /hierarchy.actm /= /actm /=.
+rewrite bindA /=.
+rewrite [X in bind m X](_ : _ = fun x => ret' x) ?bindmret //= boolp.funeqE => ?.
+by rewrite bindretf.
 Qed.
-
-Let joinA : JoinLaws.associativity join.
+Lemma joinA : JoinLaws.associativity join.
 Proof.
-move=> A; apply boolp.funext => mmma.
-by rewrite /join /= /join_of_bind bind_map compidf bindA.
+move => a; rewrite boolp.funeqE => m.
+rewrite /join /= /join'.
+rewrite /hierarchy.actm /= /actm.
+rewrite !bindA.
+congr bind.
+rewrite boolp.funeqE => u /=.
+by rewrite bindretf.
 Qed.
-
 HB.instance Definition _ := isMonad.Build M bindE joinretM joinMret joinA.
 HB.end.
 

--- a/impredicative_set/iexample_transformer.v
+++ b/impredicative_set/iexample_transformer.v
@@ -189,9 +189,7 @@ Lemma bindLmfail (M := [the monad of option_monad]) S T U (m : stateT S M U)
 Proof.
 rewrite /= /liftS; apply funext => s.
 rewrite except_bindE.
-rewrite {1}bindE /= {1}/join_of_bind /= {1}/bindS /=.
-rewrite {1}bindE /= {1}/join_of_bind /=.
-rewrite /actm /= /MS_map /= /actm /=.
+rewrite {1}bindE /= MS_mapE {1}/bindS /=.
 by case (m s) => // -[].
 Qed.
 

--- a/impredicative_set/ifmt_lifting.v
+++ b/impredicative_set/ifmt_lifting.v
@@ -44,28 +44,6 @@ Definition retK : FId ~~> MK M :=
 Definition bindK (A B : UU0) (m : MK M A) f : MK M B :=
   fun (C : UU0) (k : B -> M C) => m C (fun a : A => (f a) C k).
 
-Definition MK_map (A B : UU0) (f : A -> B) (m : MK M A) : MK M B :=
-  fun (C : UU0) (k : B -> M C) => m C (fun a : A => k (f a)).
-
-Let MK_map_i : FunctorLaws.id MK_map.
-Proof.
-move=> A; rewrite /MK_map; apply funext => m /=.
-by apply funext_dep => B; exact: funext.
-Qed.
-
-Let MK_map_o : FunctorLaws.comp MK_map. Proof. by []. Qed.
-
-HB.instance Definition _ := isFunctor.Build (MK M) MK_map_i MK_map_o.
-
-Let naturality_retK : naturality FId [the functor of MK M] retK.
-Proof.
-move=> A B h; rewrite /actm /= /MK_map /retK /=.
-by apply funext => a /=; exact: funext_dep.
-Qed.
-
-HB.instance Definition _ := isNatural.Build
-  _ [the functor of MK M] retK naturality_retK.
-
 Let left_neutral : BindLaws.left_neutral bindK retK.
 Proof.
 by move=> A B a f; rewrite /bindK /=; apply funext_dep => C; exact: funext.
@@ -79,12 +57,8 @@ Qed.
 Lemma associative : BindLaws.associative bindK.
 Proof. by move=> A B C m f g; rewrite /bindK; exact: funext_dep. Qed.
 
-Lemma fmapE (A B : UU0) (f : A -> B) (m : MK M A) :
-  ([the functor of MK M] # f) m = bindK m (@retK _ \o f).
-Proof. by []. Qed.
-
-HB.instance Definition _ := @isMonad_ret_bind.Build
-  (MK M) [the _ ~> _ of retK] bindK fmapE left_neutral right_neutral associative.
+HB.instance Definition _ :=
+  isMonad_ret_bind.Build (MK M) left_neutral right_neutral associative.
 
 Definition liftK : M ~~> MK M :=
   fun (A : UU0) (m : M A) (B : UU0) (k : A -> M B) => m >>= k.
@@ -181,7 +155,6 @@ Proof.
 apply funext => m /=.
 rewrite /from_component /psik /= /psi' /kappa' /fun_app_nt /=.
 rewrite /bindK /=.
-rewrite /join_of_bind.
 rewrite -[in RHS]compE.
 rewrite -[in RHS]compE.
 rewrite -compA.
@@ -260,25 +233,16 @@ congr (from_component _).
 apply funext_dep => A; apply funext => f.
 rewrite {1}/psi' /=.
 rewrite /bindS /=.
-rewrite /join_of_bind.
 rewrite vcompE/=.
 rewrite /liftS /=.
-rewrite -(compE _ _ emx) -functor_o.
-rewrite -[in RHS](compE _ _ emx) -functor_o.
 rewrite bindA.
 set ret_id := (X in _ >>= X).
 have -> : ret_id = fun (x : MS S (codensityT M) X) (C : UU0) => (fun t => x s C t).
   by apply funext.
-rewrite {1}bindE /= /join_of_bind /=.
-rewrite fmapE.
-rewrite /bindK /=.
 rewrite /psi' /= /bindK /kappa' /=.
-rewrite /join_of_bind /=.
-rewrite /retK /= /MK /=.
-rewrite -(compE _ _ emx).
-rewrite -functor_o.
-rewrite -[in RHS](compE _ _ emx).
-by rewrite -functor_o.
+congr (op A).
+rewrite -2![in LHS](compE _ _ emx) -2![in RHS](compE _ _ emx).
+by rewrite -!functor_o.
 Qed.
 
 End slifting_stateT.
@@ -299,14 +263,14 @@ rewrite 2!vcompE.
 set h := hmap _.
 rewrite /=.
 f_equal.
-rewrite /psi' /= /join_of_bind.
-rewrite /bindX /= bindE /= {1}/join_of_bind /=.
-rewrite fmapE.
-rewrite /bindK /=.
+rewrite /psi' /=.
+rewrite /bindX bindE /=.
 apply funext_dep => A; apply funext => k.
 rewrite vcompE/=.
-rewrite /liftX /= bindE /= /join_of_bind /= /bindK /= fmapE /= /bindK /=.
-rewrite /psi' /= /join_of_bind /= /bindK /= /kappa'.
+rewrite /liftX /=.
+rewrite bindE /= /bindK /=.
+rewrite /psi' /= /bindK /=.
+rewrite /kappa' /=.
 congr (op _ _).
 rewrite -(compE (E # _)).
 by rewrite -functor_o.
@@ -336,10 +300,10 @@ rewrite 2!functor_app_naturalE.
 rewrite /=.
 congr (from_component _).
 apply funext_dep => A; apply funext => f.
-rewrite {1}/psi' /= /join_of_bind /=.
+rewrite {1}/psi' /=.
 rewrite /bindEnv /=.
 rewrite vcompE/=.
-rewrite bindE /= /join_of_bind /= /bindK.
+rewrite bindE /= /bindK.
 rewrite fmapE /bindK.
 rewrite /liftEnv /=.
 rewrite -(compE _ _ emx) -functor_o.
@@ -370,13 +334,13 @@ rewrite (psikE op).
 rewrite 2!functor_app_naturalE.
 rewrite /=.
 f_equal.
-rewrite /psi' /= /join_of_bind /= /bindK /bindO /= bindE /= /join_of_bind /bindK /=.
+rewrite /psi' /= /bindK /bindO /= bindE /= /bindK /=.
 apply funext_dep => A; apply funext => f.
 rewrite fmapE /bindK.
 rewrite vcompE/=.
 rewrite /liftO /=.
 rewrite -(compE _ _ emx) -functor_o.
-rewrite bindE /= /join_of_bind /= /bindK /=.
+rewrite bindE /= /bindK /=.
 rewrite fmapE.
 rewrite /bindK.
 rewrite /psi' /= /bindK /= /kappa' /=.
@@ -385,7 +349,7 @@ rewrite -(compE _ _ emx) -[in RHS](compE _ _ emx).
 rewrite -2!functor_o.
 congr ((E # _) _).
 apply funext => rmx /=.
-rewrite /retK /= bindE fmapE /= /join_of_bind /= /bindK.
+rewrite /retK /= bindE fmapE /= /bindK.
 congr (Lift [the monadT of codensityT] M _ _ _ _).
 by apply funext => -[].
 Qed.
@@ -410,7 +374,7 @@ apply funext => m; apply funext => s.
 rewrite /alifting.
 rewrite /=.
 rewrite psiE /=.
-rewrite /join_of_bind /= /bindS.
+rewrite /bindS.
 rewrite vcompE/=.
 rewrite /liftS/=.
 rewrite 2!algebraic.
@@ -432,7 +396,7 @@ rewrite (slifting_exceptT aop naturality_MK Z).
 apply funext => m.
 rewrite /alifting.
 rewrite /=.
-rewrite psiE /= /join_of_bind /bindX.
+rewrite psiE /= /bindX.
 rewrite vcompE/=.
 rewrite /liftX.
 rewrite 2!algebraic.
@@ -454,7 +418,7 @@ rewrite (slifting_envT aop naturality_MK Env).
 apply funext => m; apply funext => e.
 rewrite /alifting.
 rewrite /=.
-rewrite psiE /= /join_of_bind /= /bindEnv.
+rewrite psiE /= /bindEnv.
 rewrite vcompE/=.
 rewrite /liftEnv.
 rewrite algebraic.
@@ -474,7 +438,7 @@ rewrite (slifting_outputT aop naturality_MK R).
 apply funext => m.
 rewrite /alifting.
 rewrite /=.
-rewrite psiE /= /join_of_bind /= /bindO.
+rewrite psiE /= /bindO.
 rewrite vcompE/=.
 rewrite /liftO.
 rewrite 2!algebraic.

--- a/impredicative_set/ihierarchy.v
+++ b/impredicative_set/ihierarchy.v
@@ -317,7 +317,7 @@ End monad_lemmas.
 
 Module BindLaws.
 Section bindlaws.
-Variable F : functor.
+Variable F : UU0 -> UU0.
 Variable b : forall (A B : UU0), F A -> (A -> F B) -> F B.
 Local Notation "m >>= f" := (b m f).
 
@@ -409,59 +409,108 @@ Proof. by []. Qed.
 HB.instance Definition _ := isMonad.Build M bindE joinretM joinMret joinA.
 HB.end.
 
-HB.factory Record isMonad_ret_bind (F : UU0 -> UU0) of isFunctor F := {
-  ret : FId ~> [the functor of F] ;
+HB.factory Record isMonad_ret_bind (F : UU0 -> UU0) := {
+  ret' : forall (A : UU0), A -> F A ;
   bind : forall (A B : UU0), F A -> (A -> F B) -> F B ;
-  fmapE : forall (A B : UU0) (f : A -> B) (m : F A),
-    ([the functor of F] # f) m = bind A B m (ret B \o f) ;
-  bindretf : BindLaws.left_neutral bind ret ;
-  bindmret : BindLaws.right_neutral bind ret ;
+  bindretf : BindLaws.left_neutral bind ret' ;
+  bindmret : BindLaws.right_neutral bind ret' ;
   bindA : BindLaws.associative bind }.
 
 HB.builders Context M of isMonad_ret_bind M.
 
+Let actm (a b : UU0) (f : a -> b) m := bind m (@ret' _ \o f).
+
+Let actm_id : FunctorLaws.id actm.
+Proof.
+move=> a.
+rewrite /actm; apply: funext => m /=.
+by rewrite bindmret.
+Qed.
+
+Let actm_comp : FunctorLaws.comp actm.
+Proof.
+move=> a b c g h.
+rewrite /actm; apply: funext => m /=.
+rewrite bindA.
+congr bind.
+apply: funext => u /=.
+by rewrite bindretf.
+Qed.
+
+HB.instance Definition _ := isFunctor.Build M actm_id actm_comp.
 Let F := [the functor of M].
+Local Notation FF := [the functor of F \o F].
+
+Let ret'_naturality : naturality FId F ret'.
+Proof.
+move=> a b h.
+rewrite FIdE /ihierarchy.actm /= /actm; apply: funext => m /=.
+by rewrite bindretf.
+Qed.
+
+HB.instance Definition _ :=
+  isNatural.Build FId F (ret' : FId ~~> F) ret'_naturality.
+Let ret := [the FId ~> F of ret'].
+
+Let join' : FF ~~> F := fun _ m => bind m idfun.
+
+Let actm_bind (a b c : UU0) (f : a -> b) m (g : c -> F a) :
+  (actm f) (bind m g) = bind m (actm f \o g).
+Proof. by rewrite /actm bindA. Qed.
+
+Let join'_naturality : naturality FF F join'.
+Proof.
+move=> a b h.
+rewrite /join' /=; apply: funext => mm /=.
+rewrite /ihierarchy.actm /= /isFunctor.actm /=.
+rewrite actm_bind bindA /=.
+congr bind.
+apply: funext => m /=.
+by rewrite bindretf /=.
+Qed.
+
+HB.instance Definition _ := isNatural.Build _ _ _ join'_naturality.
+Let join := [the FF ~> F of join'].
 
 Let bind_map (A B C : UU0) (f : A -> B) (m : M A) (g : B -> M C) :
   bind ((F # f) m) g = bind m (g \o f).
 Proof.
-rewrite fmapE bindA; congr bind.
-by apply funext => ?; rewrite bindretf.
+rewrite bindA; congr bind.
+by apply: funext => ?; rewrite bindretf.
 Qed.
 
-Let naturality_join :
-  naturality [the functor of F \o F] F (join_of_bind bind).
+Let bindE (a b : UU0) (f : a -> M b) (m : M a) :
+  bind m f = join b ((F # f) m).
 Proof.
-move=> A B h; apply funext => mma /=.
-rewrite fmapE /join_of_bind bindA bind_map; congr bind.
-by apply funext => ma; rewrite compidf fmapE.
+rewrite /join /= /ihierarchy.actm /= /join' /=.
+by rewrite bind_map.
 Qed.
-
-HB.instance Definition _ :=
-  isNatural.Build _ _ (join_of_bind bind) naturality_join.
-
-Let bindE (A B : UU0) (f : A -> M B) (m : M A) :
-  bind m f = (join_of_bind bind) B ((F # f) m).
-Proof. by rewrite /join /= /join_of_bind /= bind_map compidf. Qed.
-
-Let join := join_of_bind bind.
 
 Let joinretM : JoinLaws.left_unit ret join.
 Proof.
-rewrite /join => A; apply funext => ma /=.
-by rewrite /join_of_bind /= bindretf.
+move=> a; apply: funext => m.
+by rewrite /join /= /join' /= bindretf.
 Qed.
 
 Let joinMret : JoinLaws.right_unit ret join.
 Proof.
-rewrite /join => A; apply funext => ma /=.
-by rewrite /join_of_bind bind_map compidf bindmret.
+move=> a; apply: funext => m.
+rewrite /join /= /join'.
+rewrite /ihierarchy.actm /= /actm /=.
+rewrite bindA /=.
+rewrite [X in bind m X](_ : _ = fun x => ret' x) ?bindmret //=; apply: funext => ?.
+by rewrite bindretf.
 Qed.
 
 Let joinA : JoinLaws.associativity join.
 Proof.
-move=> A; apply funext => mmma.
-by rewrite /join /= /join_of_bind bind_map compidf bindA.
+move => a; apply: funext => m.
+rewrite /join /= /join'.
+rewrite /ihierarchy.actm /= /actm.
+rewrite !bindA.
+congr bind.
+apply: funext => u /=.
+by rewrite bindretf.
 Qed.
 
 HB.instance Definition _ := isMonad.Build M bindE joinretM joinMret joinA.

--- a/impredicative_set/imonad_transformer.v
+++ b/impredicative_set/imonad_transformer.v
@@ -95,34 +95,6 @@ Definition retS : FId ~~> MS := fun (A : UU0) => curry Ret.
 
 Definition bindS (A B : UU0) (m : MS A) f : MS B := fun s => m s >>= uncurry f.
 
-Definition MS_map (A B : UU0) (f : A -> B) (m : MS A) : MS B :=
-  (M # (fun x => (f x.1, x.2))) \o m.
-
-Let MS_map_i : FunctorLaws.id MS_map.
-Proof.
-move=> A; apply funext => m; apply funext => s.
-rewrite /MS_map (_ : (fun x : A * S => _) = id) ?functor_id //.
-by apply funext => -[].
-Qed.
-
-Let MS_map_o : FunctorLaws.comp MS_map.
-Proof.
-move=> A B C g h; apply funext => m; apply funext => s /=.
-by rewrite /MS_map /= -[RHS]compE -functor_o.
-Qed.
-
-HB.instance Definition _ := isFunctor.Build MS MS_map_i MS_map_o.
-
-Let naturality_retS : naturality FId [the functor of MS] retS.
-Proof.
-move=> A B h; rewrite /actm /=; apply funext => a /=.
-rewrite /MS_map /=; apply funext => s /=.
-by rewrite /retS [in LHS]curryE (natural ret).
-Qed.
-
-HB.instance Definition _ := isNatural.Build
-  FId [the functor of MS] retS naturality_retS.
-
 Let bindSretf : BindLaws.left_neutral bindS retS.
 Proof.
 by move=> A B a f; rewrite /bindS; apply funext => s; rewrite bindretf.
@@ -140,16 +112,17 @@ move=> A B C m f g; rewrite /bindS; apply funext => s.
 by rewrite bindA; bind_ext; case.
 Qed.
 
-Let MS_mapE (A B : UU0) (f : A -> B) (m : MS A) :
-  ([the functor of MS] # f) m = bindS m (@retS _ \o f).
-Proof.
-rewrite /bindS; apply funext => s.
-rewrite (_ : _ # f = MS_map f) // /MS_map [LHS]/= fmapE; congr bind.
-by apply funext => -[].
-Qed.
+HB.instance Definition _ :=
+  isMonad_ret_bind.Build MS bindSretf bindSmret bindSA.
 
-HB.instance Definition _ := isMonad_ret_bind.Build
-  MS MS_mapE bindSretf bindSmret bindSA.
+Lemma MS_mapE (A B : UU0) (f : A -> B) (m : MS A) :
+  ([the functor of MS] # f) m = (M # (fun x => (f x.1, x.2))) \o m.
+Proof.
+apply funext=> s.
+rewrite {1}/actm /= /bindS /= fmapE.
+congr bind.
+by apply: funext; case.
+Qed.
 
 Definition liftS (A : UU0) (m : M A) : MS A :=
   fun s => m >>= (fun x => Ret (x, s)).
@@ -188,25 +161,28 @@ Definition mapStateT2 (A S : UU0) (N1 N2 N3 : monad)
 Section stateMonad_of_stateT.
 Variables (S : UU0) (M : monad).
 
-Let Put : S -> MS S M unit := fun s _ => Ret (tt, s).
-Let Get : MS S M S := fun s => Ret (s, s).
+Local Notation M' := (MS S M).
+Let Put : S -> M' unit := fun s _ => Ret (tt, s).
+Let Get : M' S := fun s => Ret (s, s).
 
 Let bindputput (s s' : S) : Put s >> Put s' = Put s'.
 Proof.
-rewrite bindE /= /join_of_bind /= /bindS /=; apply funext => s0 /=.
-by rewrite bind_fmap {1}/Put bindretf.
+rewrite bindE /= /bindS.
+apply funext => s0.
+by rewrite MS_mapE bind_fmap bindretf.
 Qed.
 
 Let bindputget (s : S) : Put s >> Get = Put s >> Ret s.
 Proof.
-apply funext => s0.
-by rewrite !bindE /= /join_of_bind /= /bindS /= !bind_fmap /= 2!bindretf.
+rewrite !bindE !MS_mapE /= /bindS.
+apply funext => s'.
+by rewrite !bind_fmap !bindretf.
 Qed.
 
 Let bindgetput : Get >>= Put = skip.
 Proof.
-apply funext => s; rewrite !bindE /= /join_of_bind /= /bindS /=.
-by rewrite bind_fmap bindretf.
+rewrite bindE MS_mapE /= /bindS.
+by apply funext => s; rewrite bind_fmap bindretf.
 Qed.
 
 Let bindgetget (A : UU0) (k : S -> S -> stateT S M A) :
@@ -214,9 +190,9 @@ Let bindgetget (A : UU0) (k : S -> S -> stateT S M A) :
 Proof.
 apply funext => s.
 rewrite /Get/=.
-rewrite !bindE/= /join_of_bind/= /bindS/= /retS/=.
+rewrite !bindE !MS_mapE /= /bindS /= /retS/=.
 rewrite !bind_fmap !bindretf/=.
-rewrite !bindE/= /join_of_bind/= /bindS/= /retS/=.
+rewrite !bindE !MS_mapE /= /bindS /= /retS/=.
 by rewrite bind_fmap bindretf.
 Qed.
 
@@ -238,34 +214,6 @@ Definition retX : FId ~~> MX := fun X x => Ret (inr x).
 Definition bindX X Y (t : MX X) (f : X -> MX Y) : MX Y :=
   t >>= fun c => match c with inl z => Ret (inl z) | inr x => f x end.
 
-Definition MX_map (A B : UU0) (f : A -> B) : MX A -> MX B :=
-  M # (fun x => match x with inl y => inl y | inr y => inr (f y) end).
-
-Let MX_map_i : FunctorLaws.id MX_map.
-Proof.
-move=> A; apply funext => x; rewrite /MX in x *.
-rewrite /MX_map (_ : (fun _ => _) = id) ?functor_id //.
-by apply funext => -[].
-Qed.
-
-Let MX_map_o : FunctorLaws.comp MX_map.
-Proof.
-rewrite /MX_map => A B C g h /=; apply funext => x /=.
-rewrite -[RHS]compE -functor_o /=; congr (_ # _).
-by apply funext => -[].
-Qed.
-
-HB.instance Definition _ := isFunctor.Build MX MX_map_i MX_map_o.
-
-Let naturality_retX : naturality FId [the functor of MX] retX.
-Proof.
-move=> A B h; rewrite /retX; apply funext => /= a.
-by rewrite /actm /= /MX_map -[LHS]compE (natural ret).
-Qed.
-
-HB.instance Definition _ := isNatural.Build
-  FId [the functor of MX] retX naturality_retX.
-
 Let bindXretf : BindLaws.left_neutral bindX retX.
 Proof. by move=> A B a f; rewrite /bindX bindretf. Qed.
 
@@ -280,15 +228,17 @@ move=> A B C m f g; rewrite /bindX bindA; bind_ext; case => //.
 by move=> z; rewrite bindretf.
 Qed.
 
-Let MX_mapE (A B : UU0) (f : A -> B) (m : MX A) :
-  ([the functor of MX] # f) m = bindX m (@retX _ \o f).
-Proof.
-rewrite /bindX (_ : _ # f = MX_map f) // /MX_map fmapE; congr bind => /=.
-by apply funext => -[|].
-Qed.
+HB.instance Definition _ :=
+ isMonad_ret_bind.Build MX bindXretf bindXmret bindXA.
 
-HB.instance Definition _ := isMonad_ret_bind.Build
-  MX MX_mapE bindXretf bindXmret bindXA.
+Lemma MX_mapE (A B : UU0) (f : A -> B) :
+  [the functor of MX] # f = M # (fun x => match x with inl y => inl y | inr y => inr (f y) end).
+Proof.
+apply funext => m.
+rewrite {1}/actm /= /bindX /= [in RHS]fmapE.
+congr (_ _).
+by apply: funext; case.
+Qed.
 
 Definition liftX X (m : M X) : MX X := m >>= (@ret [the monad of MX] _).
 
@@ -384,32 +334,6 @@ Definition retEnv : FId ~~> MEnv := fun (A : UU0) a r => Ret a.
 Definition bindEnv A B (m : MEnv A) f : MEnv B :=
   fun r => m r >>= (fun a => f a r).
 
-Definition MEnv_map (A B : UU0) (f : A -> B) (m : MEnv A) : MEnv B :=
-  (M # f) \o m.
-
-Let MEnv_map_i : FunctorLaws.id MEnv_map.
-Proof.
-by move=> A; apply funext => m; rewrite /MEnv_map functor_id compidf.
-Qed.
-
-Let MEnv_map_o : FunctorLaws.comp MEnv_map.
-Proof.
-move=> A B C g h; rewrite /MEnv_map; apply funext => m /=.
-by rewrite [in RHS]compA -functor_o.
-Qed.
-
-HB.instance Definition MEnv_functor := isFunctor.Build MEnv MEnv_map_i MEnv_map_o.
-
-Let naturality_retEnv : naturality FId [the functor of MEnv] retEnv.
-Proof.
-move=> A B h; rewrite /actm /=; apply funext => a /=.
-rewrite /MEnv_map /retEnv; apply funext => r /=.
-by rewrite -[LHS](compE _ Ret) natural FIdE.
-Qed.
-
-HB.instance Definition _ := isNatural.Build
-  FId [the functor of MEnv] retEnv naturality_retEnv.
-
 Let bindEnvretf : BindLaws.left_neutral bindEnv retEnv.
 Proof.
 by move=> A B a f; rewrite /bindEnv; apply funext => r; rewrite bindretf.
@@ -427,15 +351,12 @@ move=> A B C m f g; rewrite /bindEnv; apply funext => r.
 by rewrite bindA; bind_ext; case.
 Qed.
 
-Let MEnv_mapE (A B : UU0) (f : A -> B) (m : MEnv A) :
-  ([the functor of MEnv] # f) m = bindEnv m (@retEnv _ \o f).
-Proof.
-rewrite /bindEnv; apply funext => s.
-by rewrite (_ : _ # f = MEnv_map f) // /MEnv_map [LHS]/= fmapE.
-Qed.
+HB.instance Definition _ :=
+ isMonad_ret_bind.Build MEnv bindEnvretf bindEnvmret bindEnvA.
 
-HB.instance Definition _ := isMonad_ret_bind.Build
-  MEnv MEnv_mapE bindEnvretf bindEnvmret bindEnvA.
+Lemma MEnv_mapE (A B : UU0) (f : A -> B) (m : MEnv A) :
+  ([the functor of MEnv] # f) m = (M # f) \o m.
+Proof. by apply funext=> r; rewrite /= fmapE. Qed.
 
 Definition liftEnv A (m : M A) : MEnv A := fun r => m.
 
@@ -466,33 +387,6 @@ Definition bindO A B (m : MO A) (f : A -> MO B) : MO B :=
   m >>= (fun o => let: (x, w) := o in f x >>=
   (fun o' => let (x', w') := o' in Ret (x', w ++ w'))).
 
-Definition MO_map (A B : UU0) (f : A -> B) (m : MO A) : MO B :=
-  (M # (fun x => (f x.1, x.2))) m.
-
-Let MO_map_i : FunctorLaws.id MO_map.
-Proof.
-move=> A; apply funext => m.
-rewrite /MO_map (_ : (fun _ => _) = id) ?functor_id//.
-by apply funext => -[].
-Qed.
-
-Let MO_map_o : FunctorLaws.comp MO_map.
-Proof.
-move=> A B C g h; rewrite /MO_map; apply funext => m /=.
-by rewrite -[in RHS](compE _ (M # _)) -functor_o.
-Qed.
-
-HB.instance Definition MO_functor := isFunctor.Build MO MO_map_i MO_map_o.
-
-Let naturality_retO : naturality FId [the functor of MO] retO.
-Proof.
-move=> A B h; rewrite /actm /=; apply funext => a /=.
-by rewrite /MO_map /retO -[LHS](compE _ Ret) natural FIdE.
-Qed.
-
-HB.instance Definition _ := isNatural.Build
-  FId [the functor of MO] retO naturality_retO.
-
 Let bindOretf : BindLaws.left_neutral bindO retO.
 Proof.
 move=> A B a f; rewrite /bindO /= bindretf /=.
@@ -515,16 +409,17 @@ rewrite !bindA bindretf; bind_ext; case=> x'' w''.
 by rewrite bindretf catA.
 Qed.
 
-Let MO_mapE (A B : UU0) (f : A -> B) (m : MO A) :
-  ([the functor of MO] # f) m = bindO m (@retO _ \o f).
-Proof.
-rewrite (_ : _ # f = MO_map f) // /MO_map [LHS]/= fmapE /=; congr bind.
-apply funext => -[] /= h t.
-by rewrite bindretf /= cats0.
-Qed.
+HB.instance Definition _ :=
+ isMonad_ret_bind.Build MO bindOretf bindOmret bindOA.
 
-HB.instance Definition _ := isMonad_ret_bind.Build
-  MO MO_mapE bindOretf bindOmret bindOA.
+Lemma MO_mapE (A B : UU0) (f : A -> B) (m : MO A) :
+  ([the functor of MO] # f) m = (M # (fun x => (f x.1, x.2))) m.
+Proof.
+rewrite [in LHS]/actm /= /bindO /= [in RHS]fmapE.
+congr (_ _).
+apply funext => -[] ? ?.
+by  rewrite bindretf cats0.
+Qed.
 
 Definition liftO A (m : M A) : MO A := m >>= (fun x => Ret (x, [::])).
 
@@ -564,21 +459,6 @@ Definition retC : FId ~~> MC := fun (A : UU0) (a : A) k => k a.
 
 Definition bindC A B (m : MC A) f : MC B := fun k => m (f^~ k).
 
-Definition MC_map (A B : UU0) (f : A -> B) (m : MC A) : MC B :=
-  fun k : B -> M r => m (k \o f).
-
-Let MC_map_i : FunctorLaws.id MC_map. Proof. by []. Qed.
-
-Let MC_map_o : FunctorLaws.comp MC_map. Proof. by []. Qed.
-
-HB.instance Definition _ := isFunctor.Build MC MC_map_i MC_map_o.
-
-Let naturality_retC : naturality FId [the functor of MC] retC.
-Proof. by []. Qed.
-
-HB.instance Definition _ := isNatural.Build
-  FId [the functor of MC] retC naturality_retC.
-
 Let bindCretf : BindLaws.left_neutral bindC retC.
 Proof. by []. Qed.
 
@@ -588,12 +468,12 @@ Proof. by []. Qed.
 Let bindCA : BindLaws.associative bindC.
 Proof. by []. Qed.
 
-Let MC_mapE (A B : UU0) (f : A -> B) (m : MC A) :
-  ([the functor of MC] # f) m = bindC m (@retC _ \o f).
-Proof. by []. Qed.
+HB.instance Definition _ :=
+  isMonad_ret_bind.Build MC bindCretf bindCmret bindCA.
 
-HB.instance Definition _ := isMonad_ret_bind.Build
-  MC MC_mapE bindCretf bindCmret bindCA.
+Lemma MC_mapE (A B : UU0) (f : A -> B) (m : MC A) :
+  ([the functor of MC] # f) m = fun k : B -> M r => m (k \o f).
+Proof. by []. Qed.
 
 Definition liftC A (x : M A) : MC A := fun k => x >>= k.
 
@@ -757,9 +637,7 @@ End sum.
 
 End continuation_monad_transformer_examples.
 
-(*******************)
-(* TODO: lift laws *)
-(*******************)
+(* laws about lifted fail *)
 
 Lemma bindLfailf (M : failMonad) S :
   BindLaws.left_zero (@bind (stateT S M)) (Lift _ _ ^~ fail).
@@ -982,9 +860,7 @@ Let naturality_hmapX' (F G : monad) (tau : F ~> G) :
   naturality (T F) (T G) (hmapX' tau).
 Proof.
 move=> A B h.
-rewrite /hmapX'.
-have eXh : forall G, exceptT X G # h = MX_map h by [].
-by rewrite 2!eXh /MX_map /= (natural tau).
+by rewrite /hmapX' 2!MX_mapE (natural tau).
 Qed.
 
 HB.instance Definition hmapX (F G : monad) (tau : F ~> G) :=
@@ -1014,7 +890,7 @@ Let monadMbind_hmapX (F G : monad) (e : monadM F G) :
   MonadMLaws.bind (hmapX' e).
 Proof.
 move=> A B m f; rewrite /hmapX' /=.
-rewrite !bindE /= /join_of_bind /bindX /= !bind_fmap.
+rewrite !bindE /= !MX_mapE /bindX /= !bind_fmap.
 rewrite !monadMbind /=.
 congr (bind (e (X + A)%type m) _).
 apply funext => -[x/=|//].
@@ -1059,8 +935,9 @@ move=> A B h.
 rewrite /hmapS /=.
 have H : forall G, [the monad of stateT S G] # h = [the functor of MS S G] # h by [].
 rewrite !H {H}.
-rewrite /= {1}/actm /=.
-rewrite /MS_map; apply funext => m; apply funext => s /=.
+apply funext => m /=.
+rewrite !MS_mapE.
+apply funext => s /=.
 rewrite -(compE  _ (tau (A * S)%type)).
 by rewrite natural.
 Qed.
@@ -1094,7 +971,7 @@ Let monadMbind_hmapS (F G : monad) (e : monadM F G) :
 Proof.
 move=> A B m f.
 rewrite /hmapS /=; apply funext => s.
-rewrite /= 2!bindE /= /join_of_bind /bindS /= 2!bind_fmap.
+rewrite /= 2!bindE /= !MS_mapE /bindS /= 2!bind_fmap.
 by rewrite monadMbind.
 Qed.
 
@@ -1155,8 +1032,9 @@ rewrite /hmapEnv.
 rewrite /=.
 have H : forall G, [the monad of envT E G] # h = [the functor of MEnv E G] # h by [].
 rewrite !H {H}.
-rewrite {1}/actm /=.
-rewrite /MEnv_map; apply funext => m; apply funext => s /=.
+apply funext => m /=.
+rewrite !MEnv_mapE.
+apply funext => s /=.
 rewrite -(compE  _ (tau A)).
 by rewrite natural.
 Qed.
@@ -1188,7 +1066,7 @@ Let monadMbind_hmapEnv (F G : monad) (e : monadM F G) :
 Proof.
 move=> A B m f.
 rewrite /hmapEnv /=; apply funext => s.
-rewrite /= 2!bindE /= /join_of_bind /bindEnv /= 2!bind_fmap.
+rewrite /= 2!bindE /= !MEnv_mapE /bindEnv /= 2!bind_fmap.
 by rewrite monadMbind.
 Qed.
 
@@ -1220,8 +1098,7 @@ rewrite /hmapO.
 rewrite /=.
 have H : forall G, [the monad of outputT R G] # h = [the functor of MO R G] # h by [].
 rewrite !H {H}.
-rewrite {1}/actm /=.
-rewrite /MO_map; apply funext => m /=.
+apply funext => m /=; rewrite !MO_mapE.
 rewrite -[in LHS](compE  _ (tau _)).
 by rewrite natural.
 Qed.
@@ -1252,7 +1129,7 @@ Let monadMbind_hmapO (F G : monad) (e : monadM F G) :
 Proof.
 move=> A B m f.
 rewrite /hmapO /=.
-rewrite 2!bindE /= /join_of_bind /bindO /= 2!bind_fmap.
+rewrite 2!bindE /= !MO_mapE /bindO /= 2!bind_fmap.
 rewrite !monadMbind.
 bind_ext => -[x w].
 rewrite /retO /=.

--- a/monad_model.v
+++ b/monad_model.v
@@ -436,7 +436,7 @@ Definition output : [the functor of Output.acto L \o M] ~~> M :=
   fun A m => let: (x, w') := m.2 in (x, m.1 ++ w'). (*NB: w'++m.1 in the esop paper*)
 Let naturality_output :
   naturality [the functor of Output.acto L \o M] [the functor of M] output.
-Proof. 
+Proof.
  move=> A B h.
  apply boolp.funext => -[w [x w']].
  by rewrite /output /= catA.

--- a/monad_transformer.v
+++ b/monad_transformer.v
@@ -162,9 +162,8 @@ Definition mapStateT2 (A S : UU0) (N1 N2 N3 : monad)
 Section stateMonad_of_stateT.
 Variables (S : UU0) (M : monad).
 
-Local Notation M' := (MS S M).
-Let Put : S -> M' unit := fun s _ => Ret (tt, s).
-Let Get : M' S := fun s => Ret (s, s).
+Let Put : S -> MS S M unit := fun s _ => Ret (tt, s).
+Let Get : MS S M S := fun s => Ret (s, s).
 
 Let bindputput (s s' : S) : Put s >> Put s' = Put s'.
 Proof.

--- a/monad_transformer.v
+++ b/monad_transformer.v
@@ -162,8 +162,9 @@ Definition mapStateT2 (A S : UU0) (N1 N2 N3 : monad)
 Section stateMonad_of_stateT.
 Variables (S : UU0) (M : monad).
 
-Let Put : S -> MS S M unit := fun s _ => Ret (tt, s).
-Let Get : MS S M S := fun s => Ret (s, s).
+Local Notation M' := (MS S M).
+Let Put : S -> M' unit := fun s _ => Ret (tt, s).
+Let Get : M' S := fun s => Ret (s, s).
 
 Let bindputput (s s' : S) : Put s >> Put s' = Put s'.
 Proof.

--- a/monad_transformer.v
+++ b/monad_transformer.v
@@ -117,7 +117,7 @@ HB.instance Definition _ :=
   isMonad_ret_bind.Build MS bindSretf bindSmret bindSA.
 
 Lemma MS_mapE (A B : UU0) (f : A -> B) (m : MS A) :
-  (MS # f) m = (M # (fun x => (f x.1, x.2))) \o m.
+  ([the functor of MS] # f) m = (M # (fun x => (f x.1, x.2))) \o m.
 Proof.
 apply boolp.funext=> s.
 rewrite {1}/actm /= /bindS /= fmapE.
@@ -233,7 +233,7 @@ HB.instance Definition _ :=
  isMonad_ret_bind.Build MX bindXretf bindXmret bindXA.
 
 Lemma MX_mapE (A B : UU0) (f : A -> B) :
-  MX # f = M # (fun x => match x with inl y => inl y | inr y => inr (f y) end).
+  [the functor of MX] # f = M # (fun x => match x with inl y => inl y | inr y => inr (f y) end).
 Proof.
 apply boolp.funext => m.
 rewrite {1}/actm /= /bindX /= [in RHS]fmapE.
@@ -356,7 +356,7 @@ HB.instance Definition _ :=
  isMonad_ret_bind.Build MEnv bindEnvretf bindEnvmret bindEnvA.
 
 Lemma MEnv_mapE (A B : UU0) (f : A -> B) (m : MEnv A) :
-  (MEnv # f) m = (M # f) \o m.
+  ([the functor of MEnv] # f) m = (M # f) \o m.
 Proof. by apply boolp.funext=> r; rewrite /= fmapE. Qed.
 
 Definition liftEnv A (m : M A) : MEnv A := fun r => m.
@@ -414,7 +414,7 @@ HB.instance Definition _ :=
  isMonad_ret_bind.Build MO bindOretf bindOmret bindOA.
 
 Lemma MO_mapE (A B : UU0) (f : A -> B) (m : MO A) :
-  (MO # f) m = (M # (fun x => (f x.1, x.2))) m.
+  ([the functor of MO] # f) m = (M # (fun x => (f x.1, x.2))) m.
 Proof.
 rewrite [in LHS]/actm /= /bindO /= [in RHS]fmapE.
 congr (_ _).
@@ -473,7 +473,7 @@ HB.instance Definition _ :=
   isMonad_ret_bind.Build MC bindCretf bindCmret bindCA.
 
 Lemma MC_mapE (A B : UU0) (f : A -> B) (m : MC A) :
-  (MC # f) m = fun k : B -> M r => m (k \o f).
+  ([the functor of MC] # f) m = fun k : B -> M r => m (k \o f).
 Proof. by []. Qed.
 
 Definition liftC A (x : M A) : MC A := fun k => x >>= k.

--- a/proba_monad_model.v
+++ b/proba_monad_model.v
@@ -22,6 +22,7 @@ Section monadprobmodel.
 
 Definition acto : UU0 -> UU0 := fun A => {dist (choice_of_Type A)}.
 
+(*
 Let map_id : @FunctorLaws.id (FSDist.t \o choice_of_Type)
   (fun A B => @FSDistfmap (choice_of_Type A) (choice_of_Type B)).
 Proof. by move=> A; exact: (FSDistfmap_id _). Qed.
@@ -33,10 +34,10 @@ Proof. by move=> A B C g h; exact: FSDistfmap_comp. Qed.
 HB.instance Definition _ := isFunctor.Build acto map_id map_comp.
 
 Local Notation M' := [the functor of acto].
-
-Definition ret : FId ~~> M' :=
+*)
+Definition ret : FId ~~> acto :=
   fun A a => FSDist1.d (a : choice_of_Type A).
-
+(*
 Let naturality_ret : naturality FId M' ret.
 Proof.
 move=> A B h.
@@ -45,7 +46,7 @@ Qed.
 
 HB.instance Definition _ := isNatural.Build
   _ M' ret naturality_ret.
-
+*)
 Definition bind : forall A B, acto A -> (A -> acto B) -> acto B :=
   fun A B m f => FSDistBind.d m f.
 
@@ -57,13 +58,13 @@ Proof. by move=> ? ?; exact: FSDistBindp1. Qed.
 
 Lemma associative : BindLaws.associative bind.
 Proof. by move=> A B C m f g; exact: FSDistBindA. Qed.
-
+(*
 Lemma fmapE (A B : UU0) (f : A -> B) (m : acto A) :
   ([the functor of acto] # f) m = bind _ _ m (@ret _ \o f).
 Proof. by []. Qed.
-
-HB.instance Definition _ := @isMonad_ret_bind.Build
-  acto [the _ ~> _ of ret] bind fmapE left_neutral right_neutral associative.
+*)
+HB.instance Definition _ := isMonad_ret_bind.Build
+  acto left_neutral right_neutral associative.
 
 Lemma BindE (A B : choiceType) m (f : A -> [the monad of acto] B) :
   (m >>= f) = FSDistBind.d m f.


### PR DESCRIPTION
This PR generalizes the factory `isMonad_ret_bind` in hierarchy.v to be applicable to `M : Type -> Type`, not only to `M : functor`.
