### PR TITLE
Clarify eqtype

### DIFF
--- a/example_typed_store.v
+++ b/example_typed_store.v
@@ -61,7 +61,7 @@ Inductive rlist (a : Type) (a_1 : ml_type) :=
   | Nil
   | Cons (_ : a) (_ : loc (ml_rlist a_1)).
 
-Definition ml_type_eq_mixin := EqMixin (compareP' MLTypes.ml_type_eq_dec).
+Definition ml_type_eq_mixin := EqMixin (comparePc MLTypes.ml_type_eq_dec).
 Canonical ml_type_eqType := Eval hnf in EqType _ ml_type_eq_mixin.
 
 End MLTypes.

--- a/monae_lib.v
+++ b/monae_lib.v
@@ -17,7 +17,7 @@ Definition funext_dep := boolp.functional_extensionality_dep.
 (*                foldr1                                                      *)
 (*         curry/uncurry == currying for pairs                                *)
 (*       curry3/uncurry3 == currying for triples                              *)
-(*       comparePc, eqPc == computable version of equality axioms             *)
+(*        comparePc/eqPc == computable version of equality axioms             *)
 (*  coerce T1 (v : f T1) == some (f T2) if T1 = T2 and None o.w.              *)
 (*                                                                            *)
 (******************************************************************************)

--- a/monae_lib.v
+++ b/monae_lib.v
@@ -211,40 +211,37 @@ Proof. by elim: n st => [|n IH] [|d st'] //= /IH ->. Qed.
 End nth_error.
 Arguments nth_error_size {T st n a}.
 
-(* Equality *)
-Section eqtype.
-Variable T : Type.
-Variable eq_dec : comparable T.
-Definition compareb x y : bool := eq_dec x y.
-Definition compareP' x y :=
-  match eq_dec x y as s return reflect (x = y) s with
+(* Computable equality axioms *)
+Section computable_eqtype.
+Definition comparePc T (eq_dec : comparable T) : Equality.axiom eq_dec :=
+  fun x y => match eq_dec x y as s return reflect (x = y) s with
   | left a => ReflectT (x = y) a
   | right b => ReflectF (x = y) b
   end.
-Definition eqP' (E : eqType) : Equality.axiom (@eq_op E) :=
+Definition eqPc (E : eqType) : Equality.axiom (@eq_op E) :=
   match E with EqType sort (EqMixin op a) => a end.
-End eqtype.
+End computable_eqtype.
 
 Section coerce.
 Variables (X : eqType) (f : X -> Type).
 
 Definition coerce (T1 T2 : X) (v : f T1) : option (f T2) :=
-  if @eqP' _ T1 T2 is ReflectT H then Some (eq_rect _ _ v _ H) else None.
+  if @eqPc _ T1 T2 is ReflectT H then Some (eq_rect _ _ v _ H) else None.
 
 Lemma coerce_sym (T T' : X) (s : f T) (s' : f T') : coerce T' s -> coerce T s'.
 Proof.
-by rewrite /coerce; case: eqP' => //= h; case: eqP' => //; rewrite h; auto.
+by rewrite /coerce; case: eqPc => //= h; case: eqPc => //; rewrite h; auto.
 Qed.
 
 Lemma coerce_Some (T : X) (s : f T) : coerce T s = Some s.
 Proof.
-by rewrite /coerce; case: eqP' => /= [?|]; [rewrite -eq_rect_eq|auto].
+by rewrite /coerce; case: eqPc => /= [?|]; [rewrite -eq_rect_eq|auto].
 Qed.
 
 Lemma coerce_eq (T T' : X) (s : f T) : coerce T' s -> T = T'.
-Proof. by rewrite /coerce; case: eqP'. Qed.
+Proof. by rewrite /coerce; case: eqPc. Qed.
 
 Lemma coerce_None (T T' : X) (s : f T) : T != T' -> coerce T' s = None.
-Proof. by rewrite /coerce; case: eqP'. Qed.
+Proof. by rewrite /coerce; case: eqPc. Qed.
 
 End coerce.

--- a/monae_lib.v
+++ b/monae_lib.v
@@ -17,6 +17,7 @@ Definition funext_dep := boolp.functional_extensionality_dep.
 (*                foldr1                                                      *)
 (*         curry/uncurry == currying for pairs                                *)
 (*       curry3/uncurry3 == currying for triples                              *)
+(*       comparePc, eqPc == computable version of equality axioms             *)
 (*  coerce T1 (v : f T1) == some (f T2) if T1 = T2 and None o.w.              *)
 (*                                                                            *)
 (******************************************************************************)


### PR DESCRIPTION
Clearer definition and naming of computable equality axioms `comparablePc` and `eqPc` in `monae_lib`.