### PR TITLE
Fix cputgetC and lock cchk

### DIFF
--- a/theories/applications/example_typed_store.v
+++ b/theories/applications/example_typed_store.v
@@ -130,7 +130,6 @@ under eq_bind => r1.
     rewrite bindretf bindA bindretf.
     rewrite bindA cputget.
     rewrite bindretf.
-    rewrite -bindA.
     rewrite cputgetC //.
     over.
   rewrite cnewget.
@@ -147,7 +146,7 @@ rewrite /cycle bindA -[LHS]cnewchk.
 under eq_bind => r1.
   rewrite bindA; under eq_bind do rewrite !bindA.
   under cchknewE do
-    rewrite bindretf bindA bindretf bindA cputget bindretf -bindA cputgetC //.
+    rewrite bindretf bindA bindretf bindA cputget bindretf cputgetC //.
   rewrite cnewget; over.
 rewrite cnewchk.
 by under [RHS]eq_bind do (rewrite bindA; under eq_bind do rewrite bindretf).
@@ -197,7 +196,7 @@ Lemma cchkmkrlistC A T T1 l (r : loc T) r1 k :
   = cchk r >> (mkrlist T1 l r1 >>= k) :> M A.
 Proof.
 elim: l k => [|a l IH] k /=.
-  by rewrite !bindretf -bindA cchkget.
+  by rewrite !bindretf -bindA cchkdup.
 symmetry.
 rewrite bindA -IH.
 under eq_bind do under eq_bind do rewrite -cchknewC.
@@ -251,7 +250,7 @@ under cchknewE => r2 rr2.
   under [mkrlist _ _ _ >>= _]eq_bind do rewrite rdrop_add bindA.
   rewrite IH mkrlist_drop /=.
   under [mkrlist _ _ _ >>= _]eq_bind do
-    rewrite !bindA -[cput _ _ >> _]bindA cputgetC //.
+    rewrite !bindA cputgetC //.
   under eq_bind do under eq_bind do under eq_bind do rewrite !bindretf.
   over.
 rewrite cchknewC.

--- a/theories/core/hierarchy.v
+++ b/theories/core/hierarchy.v
@@ -1151,7 +1151,7 @@ HB.mixin Record isMonadTypedStore (MLU : ML_universe) (N : monad)
     forall T1 T2 (r1 : loc locT T1) (r2 : loc locT T2) (s1 : coq_type N T1)
            (A : UU0) (k : coq_type N T2 -> M A),
       loc_id r1 != loc_id r2 ->
-    cput r1 s1 >> cget r2 >>= k =
+    cput r1 s1 >> (cget r2 >>= k) =
     cget r2 >>= (fun v => cput r1 s1 >> k v) ;
   cputnewC :
     forall T T' (r : loc locT T) (s : coq_type N T) (s' : coq_type N T') A

--- a/theories/lib/typed_store_lib.v
+++ b/theories/lib/typed_store_lib.v
@@ -21,12 +21,15 @@ Section cchk.
 Variables (MLU : ML_universe) (N : monad) (locT : eqType)
   (M : typedStoreMonad MLU N locT).
 Notation loc := (@loc MLU locT).
-Definition cchk {T} (r : loc T) : M unit := cget r >> skip.
+Definition cchk {T} : loc T -> M unit := locked (fun r  => cget r >> skip).
+
+Lemma cchkE {T} : @cchk T = fun r => cget r >> skip.
+Proof. by rewrite /cchk -lock. Qed.
 
 Lemma cnewchk T s (A : UU0) (k : loc T -> M A) :
   cnew T s >>= (fun r => cchk r >> k r) = cnew T s >>= k.
 Proof.
-under eq_bind do rewrite bindA.
+under eq_bind do rewrite cchkE bindA.
 rewrite cnewget.
 by under eq_bind do rewrite bindskipf.
 Qed.
@@ -35,7 +38,7 @@ Lemma cchknewC T1 T2 (r : loc T1) s (A : UU0) (k : loc T2 -> M A) :
   cchk r >> (cnew T2 s >>= fun r' => cchk r >> k r') =
   cchk r >> (cnew T2 s >>= k).
 Proof.
-rewrite !(bindA,bindskipf).
+rewrite cchkE !(bindA,bindskipf).
 under eq_bind do under eq_bind do rewrite bindA.
 rewrite cgetnewD.
 by under eq_bind do under eq_bind do rewrite bindskipf.
@@ -45,51 +48,51 @@ Lemma cchkgetC T1 T2 (r1: loc T1) (r2: loc T2) (A: UU0)
   (k: coq_type N T2 -> M A) :
   cchk r1 >> (cget r2 >>= k) = cget r2 >>= (fun s => cchk r1 >> k s).
 Proof.
-under [in RHS]eq_bind do rewrite bindA bindskipf.
-by rewrite !(bindA,bindskipf) cgetC.
+under [in RHS]eq_bind do rewrite cchkE bindA bindskipf.
+by rewrite cchkE !(bindA,bindskipf) cgetC.
 Qed.
 
 Lemma cchknewE T1 T2 (r1 : loc T1) s (A : UU0) (k1 k2 : loc T2 -> M A) :
   (forall r2 : loc T2, loc_id r1 != loc_id r2 -> k1 r2 = k2 r2) ->
   cchk r1 >> (cnew T2 s >>= k1) = cchk r1 >> (cnew T2 s >>= k2).
-Proof. move=> Hk; rewrite !(bindA,bindskipf); exact: cgetnewE. Qed.
+Proof. move=> Hk; rewrite cchkE !(bindA,bindskipf); exact: cgetnewE. Qed.
 
 Lemma cchknewget T T' (r : loc T) s (A : UU0) k :
   cchk r >> (cnew T' s >>= fun r' => cget r >>= k r') =
   cget r >>= (fun u => cnew T' s >>= k ^~ u) :> M A.
-Proof. by rewrite bindA bindskipf cgetnewD. Qed.
+Proof. by rewrite cchkE bindA bindskipf cgetnewD. Qed.
 
 Lemma cchknewput T T' (r : loc T) s s' (A : UU0) k :
   cchk r >> (cnew T' s' >>= fun r' => cput r s >> k r') =
   cput r s >> (cnew T' s' >>= k) :> M A.
-Proof. by rewrite bindA bindskipf cputnewC. Qed.
+Proof. by rewrite cchkE bindA bindskipf cputnewC. Qed.
 
 Lemma cchkget T (r : loc T) (A : UU0) (k : coq_type N T -> M A) :
   cchk r >> (cget r >>= k) = cget r >>= k.
-Proof. by rewrite bindA bindskipf cgetget. Qed.
+Proof. by rewrite cchkE bindA bindskipf cgetget. Qed.
 
 Lemma cgetchk T (r : loc T) (A: UU0) (k : coq_type N T -> M A) :
   cget r >>= (fun s => cchk r >> k s) = cget r >>= k.
-Proof. under eq_bind do rewrite bindA bindskipf; by rewrite cgetget. Qed.
+Proof. under eq_bind do rewrite cchkE bindA bindskipf; by rewrite cgetget. Qed.
 
 Lemma cchkputC T1 T2 (r1 : loc T1) (r2 : loc T2) (s : coq_type N T2) :
   cchk r1 >> cput r2 s = cput r2 s >> cchk r1.
-Proof. by rewrite bindA bindskipf cgetputC bindA. Qed.
+Proof. by rewrite cchkE bindA bindskipf cgetputC bindA. Qed.
 
 Lemma cchkput T (r : loc T) (s : coq_type N T) :
   cchk r >> cput r s = cput r s.
-Proof. by rewrite bindA bindskipf cgetput. Qed.
+Proof. by rewrite cchkE bindA bindskipf cgetput. Qed.
 
 Lemma cputchk T (r : loc T) (s : coq_type N T) :
   cput r s >> cchk r = cput r s.
-Proof. by rewrite cputget bindmskip. Qed.
+Proof. by rewrite cchkE cputget bindmskip. Qed.
 
 Lemma cchkC T1 T2 (r1 : loc T1) (r2 : loc T2) :
   cchk r1 >> cchk r2 = cchk r2 >> cchk r1.
-Proof. by rewrite !(bindA,bindskipf) cgetC. Qed.
+Proof. by rewrite !cchkE !(bindA,bindskipf) cgetC. Qed.
 
 Lemma cchkdup T (r : loc T) : cchk r >> cchk r = cchk r.
-Proof. by rewrite bindA bindskipf cgetget. Qed.
+Proof. by rewrite cchkE bindA bindskipf cgetget. Qed.
 
 Lemma cgetret T (r : loc T) : cget r >>= Ret = cget r :> M _.
 Proof. by rewrite bindmret. Qed.
@@ -111,7 +114,7 @@ Proof. by rewrite -(bindskipf (cnew T s)) crunnew // crunskip. Qed.
 
 Lemma crunchkget A T (m : M A) (r : A -> loc T) :
   crun (m >>= fun x => cchk (r x)) = crun (m >>= fun x => cget (r x)) :> bool.
-Proof. by rewrite /cchk -bindA crunmskip. Qed.
+Proof. by rewrite cchkE -bindA crunmskip. Qed.
 
 Lemma crunchkput A T (m : M A) (r : A -> loc T) s :
   crun (m >>= fun x => cchk (r x)) ->
@@ -122,7 +125,7 @@ Lemma crunnewchkC A T1 T2 (m : M A) (r : A -> loc T1) s :
   crun (m >>= fun x => cchk (r x)) ->
   crun (m >>= fun x => cnew T2 (s x) >> cchk (r x)).
 Proof.
-rewrite crunchkget => Hck.
+rewrite crunchkget cchkE => Hck.
 under eq_bind do rewrite -bindA.
 rewrite -bindA crunmskip.
 exact: crunnewgetC.
@@ -131,7 +134,7 @@ Qed.
 Lemma crunnewchk A T (m : M A) s :
   crun m -> crun (m >>= fun x => cnew T (s x) >>= cchk).
 Proof.
-under eq_bind do rewrite /cchk cnewget.
+under eq_bind do rewrite cchkE cnewget.
 rewrite -bindA crunmskip.
 exact: crunnew.
 Qed.

--- a/theories/models/monad_model.v
+++ b/theories/models/monad_model.v
@@ -2177,9 +2177,9 @@ Qed.
 Let cputgetC T1 T2 (r1 : loc T1) (r2 : loc T2) (s1 : coq_type T1)
     (A : UU0) (k : coq_type T2 -> M A) :
   loc_id r1 != loc_id r2 ->
-  cput r1 s1 >> cget r2 >>= k = cget r2 >>= (fun v => cput r1 s1 >> k v).
+  cput r1 s1 >> (cget r2 >>= k) = cget r2 >>= (fun v => cput r1 s1 >> k v).
 Proof.
-move=> Hr; apply/boolp.funext => e /=; rewrite !bindA.
+move=> Hr; apply/boolp.funext => e /=.
 have [u Hr1|T1' s1' Hr1 T1s'|Hr1] := ntherrorP e r1.
 - have [v Hr2|T' s' Hr2 T2s'|Hr2] := ntherrorP e r2.
   + rewrite (Some_cget _ _ _ _ Hr2).

--- a/theories/models/typed_store_model.v
+++ b/theories/models/typed_store_model.v
@@ -452,9 +452,9 @@ Qed.
 Let cputgetC T1 T2 (r1 : loc T1) (r2 : loc T2) (s1 : coq_type T1)
     (A : UU0) (k : coq_type T2 -> M A) :
   loc_id r1 != loc_id r2 ->
-  cput r1 s1 >> cget r2 >>= k = cget r2 >>= (fun v => cput r1 s1 >> k v).
+  cput r1 s1 >> (cget r2 >>= k) = cget r2 >>= (fun v => cput r1 s1 >> k v).
 Proof.
-move=> Hr; apply/boolp.funext => e /=; rewrite !bindA.
+move=> Hr; apply/boolp.funext => e /=.
 have [u Hr1|T1' s1' Hr1 T1s'|Hr1] := ntherrorP e r1.
 - have [v Hr2|T' s' Hr2 T2s'|Hr2] := ntherrorP e r2.
   + rewrite (Some_cget _ _ _ _ Hr2).


### PR DESCRIPTION
`cputgetC` had the wrong associativity, requiring to use `-bindA`, and `cchk` was not locked, creating problems when using `rewrite !bindA`.

This fixes both problems, and introduces `cchkE` to open `cchk`.