### PR TITLE
require mathcomp 2.5.0

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -17,7 +17,6 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'mathcomp/mathcomp:2.4.0-rocq-prover-9.0'
           - 'mathcomp/mathcomp:2.5.0-rocq-prover-9.0'
       fail-fast: false
     steps:

--- a/coq-monae.opam
+++ b/coq-monae.opam
@@ -19,11 +19,11 @@ build: [make "-j%{jobs}%"]
 install: [make "install_full"]
 depends: [
   "coq" { (>= "9.0" & < "9.1~") }
-  "coq-mathcomp-ssreflect" { (>= "2.4.0") }
-  "coq-mathcomp-fingroup" { (>= "2.4.0") }
-  "coq-mathcomp-algebra" { (>= "2.4.0") }
-  "coq-mathcomp-solvable" { (>= "2.4.0") }
-  "coq-mathcomp-field" { (>= "2.4.0") }
+  "coq-mathcomp-ssreflect" { (>= "2.5.0") }
+  "coq-mathcomp-fingroup" { (>= "2.5.0") }
+  "coq-mathcomp-algebra" { (>= "2.5.0") }
+  "coq-mathcomp-solvable" { (>= "2.5.0") }
+  "coq-mathcomp-field" { (>= "2.5.0") }
   "coq-mathcomp-analysis" { (>= "1.12.0")}
   "coq-infotheo" { >= "0.9.5"}
   "coq-paramcoq" { >= "1.1.3" & < "1.2~" }


### PR DESCRIPTION
bump the dependency on mathcomp from 2.4.0 to 2.5.0 (to use preorder.v in #176)