### PR TITLE
Allow rocq 9.1

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: coq-community/docker-coq-action@v1
         with:
-          opam_file: 'coq-monae.opam'
+          opam_file: 'rocq-monae.opam'
           custom_image: ${{ matrix.image }}
 
 

--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -19,6 +19,7 @@ jobs:
         image:
           - 'mathcomp/mathcomp:2.4.0-rocq-prover-9.0'
           - 'mathcomp/mathcomp:2.5.0-rocq-prover-9.0'
+          - 'mathcomp/mathcomp:2.5.0-rocq-prover-9.1'
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ clean: Makefile.coq
 	$(MAKE) -C $(SUB) clean
 
 Makefile.coq: _CoqProject
-	coq_makefile -f _CoqProject -o Makefile.coq
+	rocq makefile -f _CoqProject -o Makefile.coq
 
 _CoqProject Makefile: ;
 

--- a/meta.yml
+++ b/meta.yml
@@ -36,12 +36,14 @@ license:
 
 supported_coq_versions:
   text: Rocq 9.0
-  opam: '{ >= "9.0" & < "9.1~" }'
+  opam: '{ >= "9.0" & < "9.2~" }'
 
 tested_rocq_opam_versions:
 - version: '2.4.0-rocq-prover-9.0'
   repo: 'mathcomp/mathcomp'
 - version: '2.5.0-rocq-prover-9.0'
+  repo: 'mathcomp/mathcomp'
+- version: '2.5.0-rocq-prover-9.1'
   repo: 'mathcomp/mathcomp'
 
 dependencies:

--- a/rocq-monae.opam
+++ b/rocq-monae.opam
@@ -18,7 +18,7 @@ in several examples of monadic equational reasoning."""
 build: [make "-j%{jobs}%"]
 install: [make "install_full"]
 depends: [
-  "rocq-core" { (>= "9.0" & < "9.1~") }
+  "rocq-core" { (>= "9.0" & < "9.2~") }
   "rocq-mathcomp-ssreflect" { >= "2.4.0" }
   "rocq-mathcomp-fingroup" { >= "2.4.0" }
   "rocq-mathcomp-algebra" { >= "2.4.0" }


### PR DESCRIPTION
Just allow rocq 9.1.
Works with rocq-mathcomp.2.5 and coq-infotheo.0.9.7.