### PR TITLE
set `simpl never` to `ssrfun.comp`

### DIFF
--- a/impredicative_set/ialt_lib.v
+++ b/impredicative_set/ialt_lib.v
@@ -1,7 +1,6 @@
 (* monae: Monadic equational reasoning in Rocq                                *)
 (* Copyright (C) 2025 monae authors, license: LGPL-2.1-or-later               *)
 From mathcomp Require Import all_ssreflect.
-From mathcomp Require boolp.
 Require Import ipreamble.
 From HB Require Import structures.
 Require Import ihierarchy imonad_lib.
@@ -88,9 +87,9 @@ Lemma arbitrary_cons (T : UU0) (def : T) h t : 0 < size t ->
 Proof.
 move: def h; elim: t => // a [//|b [|c t]] ih def h _.
 - by rewrite arbitrary2.
-- by rewrite /arbitrary /= altA altC (altC (Ret b)).
-- move: (ih a h erefl); rewrite /arbitrary /= => ->.
-  move: (ih h a erefl); rewrite /arbitrary /= => ->.
+- by rewrite /arbitrary !compE /= altA altC (altC (Ret b)).
+- move: (ih a h erefl); rewrite /arbitrary !compE /= => ->.
+  move: (ih h a erefl); rewrite /arbitrary !compE /= => ->.
   by rewrite altCA.
 Qed.
 
@@ -101,7 +100,7 @@ Lemma arbitrary_naturality (T U : UU0) (a : T) (b : U) (f : T -> U) :
 Proof.
 elim=> // x [_ _ | x' xs /(_ isT)].
   by rewrite [in LHS]compE fmapE bindretf.
-rewrite [in X in X -> _]/= fmapE => ih _.
+rewrite [in X in X -> _]/= compE fmapE => ih _.
 rewrite [in RHS]compE [in RHS]/= [in RHS](arbitrary_cons b) // [in LHS]compE.
 by rewrite [in LHS]arbitrary_cons // fmapE /= alt_bindDl bindretf /= ih.
 Qed.
@@ -256,7 +255,7 @@ Local Open Scope mprog.
 Lemma insert_map (A B : UU0) (f : A -> B) (a : A) :
   insert (f a) \o map f = map f (o) insert a :> (_ -> M _).
 Proof.
-apply boolp.funext; elim => [|y xs IH].
+apply funext; elim => [|y xs IH].
   by rewrite fcompE insertE -(compE (fmap (map f))) (natural ret) compE insertE.
 apply/esym.
 rewrite fcompE insertE alt_fmapDr.
@@ -264,7 +263,7 @@ rewrite fcompE insertE alt_fmapDr.
 rewrite -(compE (fmap (map f))) (natural ret) FIdE [in X in X [~] _ ]/=.
 (* second branch *)
 rewrite -fmap_oE (_ : map f \o cons y = cons (f y) \o map f) //.
-by rewrite fmap_oE -(fcompE (map f)) -IH [RHS]/= insertE.
+by rewrite fmap_oE -(fcompE (map f)) -IH [RHS]compE insertE.
 Qed.
 
 Hypothesis Mmm : forall A, idempotent_op (@alt _ A : M A -> M A -> M A).
@@ -275,39 +274,42 @@ Lemma filter_insertN a : ~~ p a ->
   forall s, (filter p (o) insert a) s = Ret (filter p s) :> M _.
 Proof.
 move=> pa; elim => [|h t IH].
-  by rewrite fcompE insertE -(compE (fmap _)) (natural ret) FIdE /= (negbTE pa).
+  rewrite fcompE insertE -(compE (fmap _)) (natural ret) FIdE.
+  by rewrite compE/= (negbTE pa).
 rewrite fcompE insertE alt_fmapDr.
-rewrite -(compE (fmap _)) (natural ret) FIdE [in X in X [~] _]/= (negbTE pa).
+rewrite -(compE (fmap _)) (natural ret) FIdE.
+rewrite [in X in X [~] _]compE/= (negbTE pa).
 case: ifPn => ph.
 - rewrite -fmap_oE (_ : filter p \o cons h = cons h \o filter p); last first.
-    by apply boolp.funext => x /=; rewrite ph.
+    by apply funext => x /=; rewrite !compE/= ph.
   rewrite fmap_oE.
   move: (IH); rewrite fcompE => ->.
-  by rewrite fmapE /= ph bindretf /= Mmm.
+  by rewrite fmapE bindretf compE Mmm.
 - rewrite -fmap_oE (_ : filter p \o cons h = filter p); last first.
-    by apply boolp.funext => x /=; rewrite (negbTE ph).
-  by move: (IH); rewrite fcompE => -> /=; rewrite (negbTE ph) Mmm.
+    by apply funext => x /=; rewrite compE/= (negbTE ph).
+  by move: (IH); rewrite fcompE => ->; rewrite Mmm.
 Qed.
 
 Lemma filter_insertT a : p a ->
   filter p (o) insert a = insert a \o filter p :> (_ -> M _).
 Proof.
-move=> pa; apply boolp.funext; elim => [|h t IH].
-  by rewrite fcompE !insertE fmapE bindretf /= pa.
-rewrite fcompE [in RHS]/=; case: ifPn => ph.
+move=> pa; apply funext; elim => [|h t IH].
+  by rewrite fcompE !insertE fmapE bindretf compE/= pa.
+rewrite fcompE compE [in RHS]/=; case: ifPn => ph.
 - rewrite [in RHS]insertE.
-  move: (IH); rewrite [in X in X -> _]/= => <-.
+  move: (IH); rewrite compE [in X in X -> _]/= => <-.
   rewrite [in LHS]insertE alt_fmapDr; congr (_ [~] _).
-    by rewrite fmapE bindretf /= pa ph.
+    by rewrite fmapE bindretf compE/= pa ph.
   rewrite !fmapE /= fcompE bind_fmap bindA.
-  under [LHS]eq_bind do rewrite bindretf.
+  under [LHS]eq_bind do rewrite bindretf compE.
   by rewrite /= ph.
 - rewrite [in LHS]insertE alt_fmapDr.
   rewrite -[in X in _ [~] X = _]fmap_oE.
   rewrite (_ : (filter p \o cons h) = filter p); last first.
-    by apply boolp.funext => x /=; rewrite (negbTE ph).
+    by apply funext => x /=; rewrite compE/= (negbTE ph).
   move: (IH); rewrite fcompE => ->.
-  rewrite fmapE bindretf /= pa (negbTE ph) [in RHS]insertE; case: (filter _ _) => [|h' t'].
+  rewrite fmapE bindretf !compE/= pa (negbTE ph) [in RHS]insertE.
+  case: (filter _ _) => [|h' t'].
     by rewrite insertE Mmm.
   by rewrite !insertE altA Mmm.
 Qed.
@@ -334,13 +336,14 @@ Qed.
 
 Lemma rev_insert : rev (o) insert a = insert a \o rev :> (_ -> M _).
 Proof.
-apply boolp.funext; elim => [|h t ih].
+apply funext; elim => [|h t ih].
   by rewrite fcompE insertE fmapE bindretf.
 rewrite fcompE insertE compE alt_fmapDr fmapE bindretf compE [in RHS]rev_cons.
 rewrite insert_rcons rev_cons -cats1 rev_cons -cats1 -catA; congr (_ [~] _).
-move: ih; rewrite fcompE [X in X -> _]/= => <-.
-rewrite -!fmap_oE. congr (fmap _ (insert a t)).
-by apply boolp.funext => s; rewrite /= -rev_cons.
+move: ih; rewrite fcompE compE [X in X -> _]/= => <-.
+rewrite -!fmap_oE.
+congr (fmap _ (insert a t)).
+by apply funext => s; rewrite !compE/= -rev_cons.
 Qed.
 
 End insert_altCIMonad.
@@ -356,7 +359,7 @@ Local Open Scope mprog.
 Lemma iperm_o_map (A B : UU0) (f : A -> B) :
   iperm \o map f = map f (o) iperm :> (_ -> M _).
 Proof.
-apply boolp.funext; elim => [/=|x xs IH].
+apply funext; elim => [/=|x xs IH].
   by rewrite fcompE [iperm _]/= -[in RHS]compE (natural ret).
 by rewrite fcompE [in iperm _]/= fmap_bind -insert_map -bind_fmap -fcompE -IH.
 Qed.
@@ -368,7 +371,7 @@ Variables (A : UU0) (p : pred A).
 (* netys2017 *)
 Lemma iperm_filter : iperm \o filter p = filter p (o) iperm :> (_ -> M _).
 Proof.
-apply boolp.funext; elim => [|h t /= IH].
+apply funext; elim => [|h t /[!compE] /= IH].
   by rewrite fcompE fmapE bindretf.
 case: ifPn => ph.
   rewrite [in LHS]/= IH [in LHS]fcomp_def compE [in LHS]bind_fmap.
@@ -460,7 +463,7 @@ Lemma lrefin_trans A B (b a c : A -> M B) : a `<.=` b -> b `<.=` c -> a `<.=` c.
 Proof. by move => ? ? ?; exact: refin_trans. Qed.
 
 Lemma lrefin_antisym A B (a b : A -> M B) : a `<.=` b -> b `<.=` a -> a = b.
-Proof. move => ? ?; apply boolp.funext => ?; exact: refin_antisym. Qed.
+Proof. move => ? ?; apply funext => ?; exact: refin_antisym. Qed.
 End lrefin_lemmas_altCIMonad.
 
 Lemma refin_ret_insert (M : altCIMonad) (A : UU0) h (t : seq A) :

--- a/impredicative_set/iexample_transformer.v
+++ b/impredicative_set/iexample_transformer.v
@@ -189,7 +189,7 @@ Lemma bindLmfail (M := [the monad of option_monad]) S T U (m : stateT S M U)
 Proof.
 rewrite /= /liftS; apply funext => s.
 rewrite except_bindE.
-rewrite {1}bindE /= MS_mapE {1}/bindS /=.
+rewrite {1}bindE /= MS_mapE {1}/bindS compE/=.
 by case (m s) => // -[].
 Qed.
 

--- a/impredicative_set/ifmt_lifting.v
+++ b/impredicative_set/ifmt_lifting.v
@@ -68,7 +68,7 @@ Definition liftK : M ~~> MK M :=
 Let retliftK : MonadMLaws.ret liftK.
 Proof.
 move=> A; rewrite /liftK/= /retK/=; apply funext => a.
-by apply funext_dep => B /=; apply: funext => b; rewrite bindretf.
+by apply funext_dep => B /=; apply: funext => b; rewrite compE bindretf.
 Qed.
 
 Let bindliftK : MonadMLaws.bind liftK.
@@ -141,7 +141,7 @@ Definition from := [the _ ~> _ of from_component].
 Lemma from_component_liftK A :
   @from_component A \o Lift [the monadT of codensityT] M A = id.
 Proof.
-by apply funext => m /=; rewrite /from_component/= /liftK /= bindmret.
+by apply funext => m /=; rewrite /from_component/= /liftK compE/= bindmret.
 Qed.
 
 End from.
@@ -157,6 +157,7 @@ Proof.
 apply funext => m /=.
 rewrite /from_component /psik /= /psi' /kappa' /fun_app_nt /=.
 rewrite /bindK /=.
+rewrite !compE.
 rewrite -[in RHS]compE.
 rewrite -[in RHS]compE.
 rewrite -compA.
@@ -237,7 +238,7 @@ rewrite {1}/psi' /=.
 rewrite /bindS /=.
 rewrite vcompE/=.
 rewrite /liftS /=.
-rewrite bindA.
+rewrite compE bindA.
 set ret_id := (X in _ >>= X).
 have -> : ret_id = fun (x : MS S (codensityT M) X) (C : UU0) => (fun t => x s C t).
   by apply funext.
@@ -263,14 +264,14 @@ rewrite (psikE op (Z + X)%type).
 rewrite /slifting.
 rewrite 2!vcompE.
 set h := hmap _.
-rewrite /=.
+rewrite !compE/=.
 f_equal.
 rewrite /psi' /=.
-rewrite /bindX bindE /=.
+rewrite /bindX compE bindE /=.
 apply funext_dep => A; apply funext => k.
 rewrite vcompE/=.
 rewrite /liftX /=.
-rewrite bindE /= /bindK /=.
+rewrite compE bindE /= /bindK /=.
 rewrite /psi' /= /bindK /=.
 rewrite /kappa' /=.
 congr (op _ _).
@@ -305,9 +306,10 @@ apply funext_dep => A; apply funext => f.
 rewrite {1}/psi' /=.
 rewrite /bindEnv /=.
 rewrite vcompE/=.
-rewrite bindE /= /bindK.
+rewrite compE bindE /= /bindK.
 rewrite fmapE /bindK.
 rewrite /liftEnv /=.
+rewrite /phi' !compE/=.
 rewrite -(compE _ _ emx) -functor_o.
 rewrite -[in RHS](compE _ _ emx) -functor_o.
 rewrite /psi' /= /bindK /= /kappa' /=.
@@ -334,24 +336,27 @@ rewrite 2!vcompE.
 set h := hmap _.
 rewrite (psikE op).
 rewrite 2!functor_app_naturalE.
-rewrite /=.
+rewrite !compE/=.
 f_equal.
-rewrite /psi' /= /bindK /bindO /= bindE /= /bindK /=.
+rewrite /psi' /= /bindK /bindO /= compE bindE /= /bindK /=.
 apply funext_dep => A; apply funext => f.
 rewrite fmapE /bindK.
 rewrite vcompE/=.
 rewrite /liftO /=.
-rewrite -(compE _ _ emx) -functor_o.
+rewrite /kappa' !compE/=.
+rewrite -[in RHS](compE _ _ emx) -functor_o.
 rewrite bindE /= /bindK /=.
 rewrite fmapE.
 rewrite /bindK.
-rewrite /psi' /= /bindK /= /kappa' /=.
+rewrite /psi' /= /bindK /=.
 congr (op A).
-rewrite -(compE _ _ emx) -[in RHS](compE _ _ emx).
-rewrite -2!functor_o.
+rewrite -[in LHS](compE _ _ emx).
+rewrite -functor_o.
+rewrite -[LHS]compE.
+rewrite -functor_o.
 congr ((E # _) _).
 apply funext => rmx /=.
-rewrite /retK /= bindE fmapE /= /bindK.
+rewrite /retK !compE/= bindE fmapE /= /bindK.
 congr (Lift [the monadT of codensityT] M _ _ _ _).
 by apply funext => -[].
 Qed.
@@ -379,6 +384,7 @@ rewrite psiE /=.
 rewrite /bindS.
 rewrite vcompE/=.
 rewrite /liftS/=.
+rewrite !compE/=.
 rewrite 2!algebraic.
 congr (aop _ _).
 rewrite -[RHS](compE _ (E # _)).
@@ -387,7 +393,7 @@ rewrite -[RHS](compE _ (E # _)).
 rewrite -functor_o.
 congr ((E # _) m).
 apply funext => x /=.
-by rewrite 2!bindretf.
+by rewrite !compE/= 2!bindretf.
 Qed.
 
 Lemma slifting_alifting_exceptFMT (Z : UU0) (t := [the fmt of exceptT Z]) :
@@ -401,7 +407,7 @@ rewrite /=.
 rewrite psiE /= /bindX.
 rewrite vcompE/=.
 rewrite /liftX.
-rewrite 2!algebraic.
+rewrite !compE 2!algebraic.
 congr (aop _ _).
 rewrite -[RHS](compE _ (E # _)).
 rewrite -functor_o.
@@ -409,7 +415,7 @@ rewrite -[RHS](compE _ (E # _)).
 rewrite -functor_o.
 rewrite (_ : _ \o Ret = id) ?functor_id //.
 apply funext => n /=.
-by rewrite 2!bindretf.
+by rewrite !compE/= 2!bindretf.
 Qed.
 
 Lemma slifting_alifting_envFMT (Env : UU0) (t := [the fmt of envT Env]) :
@@ -423,13 +429,13 @@ rewrite /=.
 rewrite psiE /= /bindEnv.
 rewrite vcompE/=.
 rewrite /liftEnv.
-rewrite algebraic.
+rewrite compE algebraic.
 congr (aop _ _).
 rewrite -[RHS](compE _ (E # _)).
 rewrite -functor_o.
 congr ((E # _) m).
 apply funext => x /=.
-by rewrite bindretf.
+by rewrite compE/= bindretf.
 Qed.
 
 Lemma slifting_alifting_outputFMT (R : UU0) (t := [the fmt of outputT R]) :
@@ -443,7 +449,7 @@ rewrite /=.
 rewrite psiE /= /bindO.
 rewrite vcompE/=.
 rewrite /liftO.
-rewrite 2!algebraic.
+rewrite !compE 2!algebraic.
 congr (aop _ _).
 rewrite -[RHS](compE _ (E # _)).
 rewrite -functor_o.
@@ -451,7 +457,7 @@ rewrite -[RHS](compE _ (E # _)).
 rewrite -functor_o.
 rewrite (_ : _ \o Ret = id) ?functor_id //.
 apply funext => n /=.
-rewrite 2!bindretf.
+rewrite !compE/= 2!bindretf.
 Open (X in _ >>= X).
   by case : x => ? ?; rewrite cat0s.
 by rewrite bindmret.

--- a/impredicative_set/ihierarchy.v
+++ b/impredicative_set/ihierarchy.v
@@ -481,7 +481,7 @@ Let actm_comp : FunctorLaws.comp actm.
 Proof.
 move=> a b c g h.
 rewrite /actm; apply: funext => m /=.
-rewrite bindA.
+rewrite compE bindA.
 congr bind.
 apply: funext => u /=.
 by rewrite bindretf.
@@ -495,7 +495,7 @@ Let ret_naturality : naturality idfun F ret.
 Proof.
 move=> a b h.
 rewrite FIdE /ihierarchy.actm /= /actm; apply: funext => m /=.
-by rewrite bindretf.
+by rewrite compE bindretf.
 Qed.
 
 HB.instance Definition _ :=
@@ -512,7 +512,7 @@ Proof.
 move=> a b h.
 rewrite /join' /=; apply: funext => mm /=.
 rewrite /ihierarchy.actm /= /isFunctor.actm /=.
-rewrite actm_bind bindA /=.
+rewrite !compE actm_bind bindA /=.
 congr bind.
 apply: funext => m /=.
 by rewrite bindretf /=.
@@ -538,7 +538,7 @@ Qed.
 Let joinretM : JoinLaws.left_unit ret join.
 Proof.
 move=> a; apply: funext => m.
-by rewrite /join /= /join' /= bindretf.
+by rewrite /join /= /join' /= compE bindretf.
 Qed.
 
 Let joinMret : JoinLaws.right_unit ret join.
@@ -546,7 +546,7 @@ Proof.
 move=> a; apply: funext => m.
 rewrite /join /= /join'.
 rewrite /ihierarchy.actm /= /actm /=.
-rewrite bindA /=.
+rewrite compE bindA /=.
 rewrite [X in bind m X](_ : _ = fun x => ret x) ?bindmret //=; apply: funext => ?.
 by rewrite bindretf.
 Qed.
@@ -556,7 +556,7 @@ Proof.
 move => a; apply: funext => m.
 rewrite /join /= /join'.
 rewrite /ihierarchy.actm /= /actm.
-rewrite !bindA.
+rewrite compE [in RHS]compE !bindA.
 congr bind.
 apply: funext => u /=.
 by rewrite bindretf.
@@ -667,7 +667,7 @@ Proof. by []. Qed.
 
 Lemma kleisliE A B C (g : B -> M C) (f : A -> M B) (a : A) :
   (f >=> g) a = (f a) >>= g.
-Proof. by rewrite /kleisli /= join_fmap. Qed.
+Proof. by rewrite /kleisli !compE join_fmap. Qed.
 
 Lemma bind_kleisli A B C m (f : A -> M B) (g : B -> M C) :
   m >>= (f >=> g) = (m >>= f) >>= g.

--- a/impredicative_set/imonad_composition.v
+++ b/impredicative_set/imonad_composition.v
@@ -5,7 +5,7 @@ From HB Require Import structures.
 Require Import ipreamble ihierarchy imonad_lib.
 
 (**md**************************************************************************)
-(*                          Composing monads                                  *)
+(* # Composing monads                                                         *)
 (*                                                                            *)
 (* formalization of [Jones and Duponcheel, Composing Monads, Yale RR 1993]    *)
 (* (Sections 2 and 3)                                                         *)
@@ -69,7 +69,7 @@ Proof.
 move=> A; rewrite /JOIN'.
 rewrite /=.
 rewrite /CRet.
-rewrite compA.
+rewrite (compA JOIN).
 rewrite -(compA Join (M # prod) Ret) (natural ret).
 by rewrite [LHS]compA (compA Join) joinretM compidf Hprod2.
 Qed.
@@ -78,7 +78,8 @@ Lemma JOIN_fmap_ret : JoinLaws.right_unit (@CRet M N) (@JOIN').
 Proof.
 move=> A.
 rewrite /JOIN' /=.
-rewrite -compA.
+rewrite -(compA Join).
+rewrite -[LHS]compA.
 rewrite FCompE.
 rewrite -(@functor_o M).
 by rewrite Hprod3 joinMret.
@@ -87,14 +88,14 @@ Qed.
 Lemma JOIN_fmap_JOIN : JoinLaws.associativity (@JOIN').
 Proof.
 move=> A; rewrite {1 2}/JOIN' -[LHS]compA /=.
-rewrite -functor_o.
+rewrite -(@functor_o M).
 rewrite Hprod4.
 rewrite {1}/JOIN.
 rewrite -(compA Join (M # prod) prod).
 rewrite functor_o.
 rewrite [LHS]compA.
 rewrite joinA.
-rewrite -compA.
+rewrite -(compA Join).
 rewrite functor_o.
 rewrite (compA Join (M # (M # prod)) (M # prod)).
 by rewrite -(natural _).

--- a/impredicative_set/imonad_lib.v
+++ b/impredicative_set/imonad_lib.v
@@ -85,7 +85,7 @@ Lemma mfoldl_rev (T R : UU0) (f : R -> T -> R) (z : R)
   foldl f z (o) (rev (o) s) = foldr (fun x => f^~ x) z (o) s.
 Proof.
 apply funext => x; rewrite !fcompE 3!fmapE !bindA.
-bind_ext => ?; by rewrite bindretf /= -foldl_rev.
+by bind_ext => ?; rewrite bindretf compE foldl_rev.
 Qed.
 Local Close Scope mprog.
 
@@ -590,15 +590,15 @@ apply: (@AdjointFunctor.mk _ _ uni couni).
   rewrite (_ : @eps0 _ \o F0 # _ = @eta (F0 A)).
     exact: (AdjointFunctor.tri_left H).
   rewrite functor_o [LHS]compA -FCompE.
-  rewrite -(natural (AdjointFunctor.eps H0)) /= FIdE -compA.
+  rewrite -(natural (AdjointFunctor.eps H0)) /= FIdE -[LHS]compA.
   by rewrite (AdjointFunctor.tri_left H0) compfid.
 rewrite /TriangularLaws.right => A.
 rewrite /couni /uni /=.
-rewrite compA -[RHS](AdjointFunctor.tri_right H0 (U A)); congr (_ \o _).
-rewrite FCompE -functor_o; congr (_ # _).
-rewrite functor_o -compA -FCompE.
+rewrite [LHS]compA -[RHS](AdjointFunctor.tri_right H0 (U A)); congr (_ \o _).
+rewrite FCompE -(@functor_o U0); congr (_ # _).
+rewrite functor_o -compA.
 rewrite (natural (AdjointFunctor.eta H)) FIdE.
-by rewrite compA (AdjointFunctor.tri_right H) compidf.
+by rewrite [LHS]compA (AdjointFunctor.tri_right H) compidf.
 Qed.
 
 End composite_adjoint.

--- a/impredicative_set/imonad_model.v
+++ b/impredicative_set/imonad_model.v
@@ -301,7 +301,7 @@ Let left_neutral : BindLaws.left_neutral bind ret.
 Proof. by move=> A B a f; apply funext. Qed.
 Let right_neutral : BindLaws.right_neutral bind ret.
 Proof.
-by move=> A f; apply funext => s; rewrite /bind /=; case: (f s).
+by move=> A f; apply funext => s; rewrite /bind compE/=; case: (f s).
 Qed.
 Let associative : BindLaws.associative bind.
 Proof.
@@ -334,7 +334,7 @@ Let left_neutral : BindLaws.left_neutral bind ret.
 Proof. by move=> A B a f; apply funext. Qed.
 Let right_neutral : BindLaws.right_neutral bind ret.
 Proof.
-by move=> A f; apply funext => s; rewrite /bind /=; case: (f s).
+by move=> A f; apply funext => s; rewrite /bind compE/=; case: (f s).
 Qed.
 Let associative : BindLaws.associative bind.
 Proof.
@@ -424,8 +424,9 @@ Definition append : Append.acto \o M ~~> M :=
 Let naturality_append : naturality (Append.acto \o M) M append.
 Proof.
 move=> A B h; apply funext => -[s1 s2] /=.
-rewrite /actm /=.
-by rewrite map_cat flatten_cat.
+rewrite [LHS]fmapE [LHS]list_bindE.
+rewrite [in LHS]map_cat.
+by rewrite [in LHS]flatten_cat.
 Qed.
 
 HB.instance Definition _ :=
@@ -479,7 +480,7 @@ Let naturality_output :
 Proof.
 move=> A B h.
 apply: funext => -[w [x w']].
-by rewrite /output /= catA.
+by rewrite /output !compE/= catA.
 Qed.
 
 HB.instance Definition _ := isNatural.Build
@@ -1235,17 +1236,17 @@ Definition aput i s : M unit := fun a => (tt, insert i s a).
 Let aputput i s s' : aput i s >> aput i s' = aput i s'.
 Proof.
 rewrite state_bindE; apply funext => a/=.
-by rewrite /aput insert_insert.
+by rewrite /aput compE/= insert_insert.
 Qed.
 Let aputget i s A (k : S -> M A) : aput i s >> aget i >>= k = aput i s >> k s.
 Proof.
 rewrite state_bindE; apply funext => a/=.
-by rewrite /aput insert_same.
+by rewrite /aput compE/= insert_same.
 Qed.
 Let agetput i : aget i >>= aput i = skip.
 Proof.
 rewrite state_bindE; apply funext => a/=.
-by rewrite /aput insert_same2.
+by rewrite /aput compE/= insert_same2.
 Qed.
 Let agetget i A (k : S -> S -> M A) :
   aget i >>= (fun s => aget i >>= k s) = aget i >>= fun s => k s s.
@@ -1258,13 +1259,13 @@ Let aputC i j u v : (i != j) \/ (u = v) ->
   aput i u >> aput j v = aput j v >> aput i u.
 Proof.
 by move=> [ij|->{u}]; rewrite !state_bindE /aput; apply/funext => a/=;
-  [rewrite insertC|rewrite insertC2].
+  [rewrite compE/= insertC|rewrite compE/= insertC2].
 Qed.
 Let aputgetC i j u A (k : S -> M A) : i != j ->
   aput i u >> aget j >>= k = aget j >>= (fun v => aput i u >> k v).
 Proof.
 move=> ij; rewrite /aput !state_bindE; apply funext => a/=.
-by rewrite state_bindE/= {1}/insert (negbTE ij).
+by rewrite !compE/= state_bindE/= {1}/insert (negbTE ij).
 Qed.
 HB.instance Definition _ := Monad.on M.
 HB.instance Definition _ := isMonadArray.Build
@@ -1484,7 +1485,7 @@ Let runStateTbind : forall (A B : UU0) (m : M A) (f : A -> M B) (s : S),
 Proof.
 move=> A M m f s /=.
 rewrite /= /runStateT bindE /= /join_of_bind /bindS /=.
-rewrite MS_mapE /actm /=.
+rewrite MS_mapE /actm !compE/=.
 by case: (m s).
 Qed.
 Let runStateTget : forall s : S, runStateT get s = Ret (s, s) :> N _.

--- a/impredicative_set/imonad_transformer.v
+++ b/impredicative_set/imonad_transformer.v
@@ -76,7 +76,7 @@ HB.builders Context (M N : monad) (e : M ~~> N) of isMonadM_ret_bind M N e.
 Lemma naturality_monadM : naturality M N e.
 Proof.
 move=> A B h; apply funext => m /=.
-by rewrite !fmapE monadMbind (compA (e B)) monadMret.
+by rewrite !compE !fmapE monadMbind (compA (e B)) monadMret.
 Qed.
 
 HB.instance Definition _ := isNatural.Build M N e naturality_monadM.
@@ -123,7 +123,7 @@ Lemma MS_mapE (A B : UU0) (f : A -> B) (m : MS A) :
   ([the functor of MS] # f) m = (M # (fun x => (f x.1, x.2))) \o m.
 Proof.
 apply funext=> s.
-rewrite {1}/actm /= /bindS /= fmapE.
+rewrite {1}/actm /= /bindS compE/= fmapE.
 congr bind.
 by apply: funext; case.
 Qed.
@@ -134,7 +134,7 @@ Definition liftS (A : UU0) (m : M A) : MS A :=
 Let retliftS : MonadMLaws.ret liftS.
 Proof.
 move=> A; rewrite /liftS; apply: funext => a /=; apply: funext => s /=.
-by rewrite bindretf.
+by rewrite compE bindretf.
 Qed.
 
 Let bindliftS : MonadMLaws.bind liftS.
@@ -198,7 +198,7 @@ apply: funext => s.
 rewrite /Get/=.
 rewrite !bindE !MS_mapE /= /bindS /= /retS/=.
 rewrite !bind_fmap !bindretf/=.
-rewrite !bindE !MS_mapE /= /bindS /= /retS/=.
+rewrite !compE !bindE !MS_mapE /= /bindS /= /retS/=.
 by rewrite bind_fmap bindretf.
 Qed.
 
@@ -250,7 +250,7 @@ Definition liftX X (m : M X) : MX X := m >>= (@ret [the monad of MX] _).
 
 Let retliftX : MonadMLaws.ret liftX.
 Proof.
-by move=> A; apply: funext => a; rewrite /liftX /= bindretf.
+by move=> A; apply: funext => a; rewrite /liftX compE/= bindretf.
 Qed.
 
 Let bindliftX : MonadMLaws.bind liftX.
@@ -261,7 +261,7 @@ rewrite /= /join_of_bind /bindX /= !bindA.
 rewrite 2!joinE !bindA.
 bind_ext => a.
 rewrite 3!bindretf.
-rewrite /liftX /=.
+rewrite /liftX compE/=.
 bind_ext => b.
 by rewrite bindretf.
 Qed.
@@ -362,7 +362,7 @@ HB.instance Definition _ :=
 
 Lemma MEnv_mapE (A B : UU0) (f : A -> B) (m : MEnv A) :
   (MEnv # f) m = (M # f) \o m.
-Proof. by apply: funext => r; rewrite /= fmapE. Qed.
+Proof. by apply: funext => r; rewrite compE/= fmapE. Qed.
 
 Definition liftEnv A (m : M A) : MEnv A := fun r => m.
 
@@ -432,7 +432,7 @@ Definition liftO A (m : M A) : MO A := m >>= (fun x => Ret (x, [::])).
 Let retliftO : MonadMLaws.ret liftO.
 Proof.
 move=> a; rewrite /liftO /= /retO; apply: funext => o /=.
-by rewrite bindretf.
+by rewrite compE bindretf.
 Qed.
 
 Let bindliftO : MonadMLaws.bind liftO.
@@ -486,7 +486,7 @@ Definition liftC A (x : M A) : MC A := fun k => x >>= k.
 Let retliftC : MonadMLaws.ret liftC.
 Proof.
 move => A; rewrite /liftC; apply: funext => a /=.
-by apply: funext => s; rewrite bindretf.
+by apply: funext => s; rewrite compE bindretf.
 Qed.
 
 Let bindliftC : MonadMLaws.bind liftC.
@@ -708,7 +708,7 @@ transitivity (Join ((M # (Join \o (M # g))) (n (M A) t))); last first.
   apply: funext => ma.
   by rewrite bindE.
 rewrite -[in X in Join X = _]compE.
-rewrite (natural join).
+rewrite compE natural.
 rewrite functor_o.
 rewrite -[in RHS]FCompE.
 rewrite -[RHS]compE.
@@ -760,6 +760,7 @@ Lemma psiK (op : E ~> M) : phi (psi op) = op.
 Proof.
 apply/nattrans_ext => A.
 rewrite phiE /= psiE; apply: funext => m /=.
+rewrite !compE.
 rewrite -(compE (op _)) -(natural op) -(compE Join).
 by rewrite compA joinMret.
 Qed.
@@ -769,6 +770,7 @@ Proof.
 apply/aoperation_ext => A.
 rewrite /=.
 rewrite psiE phiE; apply funext => m /=.
+rewrite !compE.
 rewrite -(compE (op _)) joinE.
 rewrite (algebraic op).
 rewrite -(compE (E # _)) -functor_o.
@@ -887,7 +889,7 @@ Let monadMret_hmapX (F G : monad) (e : monadM F G) :
   MonadMLaws.ret (hmapX' e).
 Proof.
 move=> A; apply: funext => /= a.
-by rewrite /hmapX' /retX /= -(compE (e _)) monadMret.
+by rewrite /hmapX' /retX !compE/= -(compE (e _)) monadMret.
 Qed.
 
 Let monadMbind_hmapX (F G : monad) (e : monadM F G) :
@@ -898,7 +900,7 @@ rewrite !bindE /= !MX_mapE /bindX /= !bind_fmap.
 rewrite !monadMbind /=.
 congr (bind (e (X + A)%type m) _).
 apply funext => -[x/=|//].
-by rewrite -(compE (e _)) monadMret.
+by rewrite !compE/= -(compE (e _)) monadMret.
 Qed.
 
 Let hmapX_lift :
@@ -912,10 +914,10 @@ rewrite /liftX /=.
 rewrite /retX /=.
 apply: funext => ma /=.
 rewrite (_ : (fun x : A => Ret (inr x)) = Ret \o inr) //.
-rewrite -bind_fmap.
+rewrite compE -bind_fmap.
 rewrite bindmret.
 rewrite (_ : (fun x : A => Ret (inr x)) = Ret \o inr) //.
-rewrite -bind_fmap.
+rewrite compE -bind_fmap.
 rewrite bindmret.
 rewrite -(compE (N # inr)).
 by rewrite (natural t).
@@ -940,10 +942,9 @@ rewrite /hmapS /=.
 have H : forall G, [the monad of stateT S G] # h = [the functor of MS S G] # h by [].
 rewrite !H {H}.
 apply: funext => m /=.
-rewrite !MS_mapE.
+rewrite !compE !MS_mapE.
 apply: funext => s /=.
-rewrite -(compE  _ (tau (A * S)%type)).
-by rewrite natural.
+by rewrite [in LHS]compE -(compE  _ (tau (A * S)%type)) natural.
 Qed.
 
 HB.instance Definition _ (F G : monad) (tau : F ~> G) := isNatural.Build
@@ -966,7 +967,7 @@ Let monadMret_hmapS (F G : monad) (e : monadM F G) :
 Proof.
 move=> A; apply funext => /= a.
 rewrite /hmapS /= /retS /=; apply: funext => s.
-by rewrite [in LHS]curryE monadMret.
+by rewrite compE [in LHS]curryE monadMret.
 Qed.
 
 Let monadMbind_hmapS (F G : monad) (e : monadM F G) :
@@ -988,7 +989,7 @@ rewrite /hmapS /=.
 rewrite /liftS /=.
 apply: funext => ma /=.
 apply: funext => s /=.
-rewrite ![in LHS]bindE ![in LHS]fmapE ![in LHS]bindE.
+rewrite !compE ![in LHS]bindE ![in LHS]fmapE ![in LHS]bindE.
 rewrite 2!(_ : (fun x : A => Ret (x, s)) = Ret \o (fun x => (x, s))) //.
 rewrite functor_o.
 rewrite -(compE Join (_ \o _)).
@@ -1003,7 +1004,7 @@ rewrite -(compE _ (t A)).
 rewrite -(compE (t _)).
 rewrite -natural.
 rewrite /=.
-rewrite ![in RHS]bindE ![in RHS]fmapE ![in RHS]bindE.
+rewrite !compE ![in RHS]bindE ![in RHS]fmapE ![in RHS]bindE.
 rewrite functor_o.
 rewrite -(compE Join (_ \o _)).
 rewrite (compA Join (N # _)).
@@ -1036,9 +1037,9 @@ rewrite /=.
 have H : forall G, [the monad of envT E G] # h = [the functor of MEnv E G] # h by [].
 rewrite !H {H}.
 apply: funext => m /=.
-rewrite !MEnv_mapE.
+rewrite !compE !MEnv_mapE.
 apply: funext => s /=.
-rewrite -(compE  _ (tau A)).
+rewrite !compE -(compE  _ (tau A)).
 by rewrite natural.
 Qed.
 
@@ -1100,7 +1101,7 @@ rewrite /hmapO.
 rewrite /=.
 have H : forall G, [the monad of outputT R G] # h = [the functor of MO R G] # h by [].
 rewrite !H {H}.
-apply funext => m /=; rewrite !MO_mapE.
+apply funext => m /=; rewrite !compE !MO_mapE.
 rewrite -[in LHS](compE  _ (tau _)).
 by rewrite natural.
 Qed.
@@ -1134,7 +1135,7 @@ rewrite 2!bindE /= !MO_mapE /bindO /= 2!bind_fmap.
 rewrite !monadMbind.
 bind_ext => -[x w].
 rewrite /retO /=.
-rewrite monadMbind.
+rewrite !compE monadMbind.
 bind_ext => /= -[h t] /=.
 rewrite -[LHS](compE _ Ret (h, _)).
 by rewrite monadMret.
@@ -1148,7 +1149,7 @@ Proof.
 move=> h M N t; apply/nattrans_ext => A /=; rewrite !vcompE/=.
 rewrite /hmapO /= /liftO /=.
 apply: funext => ma /=.
-rewrite -!fmapE.
+rewrite !compE -!fmapE.
 rewrite -(compE _ (t A)).
 by rewrite natural.
 Qed.

--- a/impredicative_set/ipreamble.v
+++ b/impredicative_set/ipreamble.v
@@ -13,6 +13,8 @@ Definition funext := @FunctionalExtensionality.functional_extensionality.
 
 Definition funext_dep := @FunctionalExtensionality.functional_extensionality_dep.
 
+Arguments ssrfun.comp {A B C} : simpl never.
+
 (**md**************************************************************************)
 (* # Shared notations and easy definitions/lemmas of general interest         *)
 (*                                                                            *)
@@ -27,6 +29,9 @@ Definition funext_dep := @FunctionalExtensionality.functional_extensionality_dep
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
+
+Lemma compE A B C (g : B -> C) (f : A -> B) a : (g \o f) a = g (f a).
+Proof. by []. Qed.
 
 (* notations common to hierarchy.v and category.v *)
 
@@ -91,7 +96,7 @@ Variables (U : Type) (h : U -> R) (w : U) (g : T -> U -> U).
 Hypothesis H1 : h w = r.
 Hypothesis H2 : forall x y, h (g x y) = f x (h y).
 Lemma foldr_fusion : h \o foldr g w = foldr f r.
-Proof. by apply funext; elim => // a b /= ih; rewrite H2 ih. Qed.
+Proof. by apply funext; elim => // a b /= <-; rewrite compE H2. Qed.
 Lemma foldr_fusion_ext x : (h \o foldr g w) x = foldr f r x.
 Proof. by rewrite -foldr_fusion. Qed.
 End fusion_law.
@@ -149,9 +154,6 @@ Proof. by []. Qed.
 Lemma compfid A B (f : A -> B) : f \o id = f. Proof. by []. Qed.
 
 Lemma compidf A B (f : A -> B) : id \o f = f. Proof. by []. Qed.
-
-Lemma compE A B C (g : B -> C) (f : A -> B) a : (g \o f) a = g (f a).
-Proof. by []. Qed.
 
 Lemma if_pair A B b (x : A) y (u : A) (v : B) :
   (if b then (x, y) else (u, v)) = (if b then x else u, if b then y else v).

--- a/impredicative_set/istate_lib.v
+++ b/impredicative_set/istate_lib.v
@@ -278,7 +278,7 @@ case: assertPn => ps; last first.
   rewrite bindfailf.
   With (idtac) Open (X in _ >>= X).
     rewrite /assert; unlock => /=.
-    rewrite (negbTE (segment_closed_suffix ps x)) guardF bindfailf.
+    rewrite compE (negbTE (segment_closed_suffix ps x)) guardF bindfailf.
     reflexivity.
   by rewrite right_z.
 rewrite bindretf bindA /=.
@@ -286,9 +286,9 @@ under [RHS]eq_bind do rewrite bindretf.
 rewrite bindA.
 bind_ext => t.
 case: (assertPn _ _ t) => pt; last first.
-  rewrite bindfailf assertE (negbTE (segment_closed_prefix pt s)) guardF.
+  rewrite bindfailf compE assertE (negbTE (segment_closed_prefix pt s)) guardF.
   by rewrite bindfailf.
-by rewrite bindretf /=  2!assertE promotable_pq //= bindA bindretf.
+by rewrite bindretf compE/= 2!assertE promotable_pq //= bindA bindretf.
 Qed.
 
 Section examples_promotable_segment_closed.
@@ -414,7 +414,7 @@ rewrite putget.
 rewrite bindA.
 rewrite bindretf.
 rewrite putput.
-by rewrite /= addSnnS.
+by rewrite compE/= addSnnS.
 Qed.
 
 End tick_fusion.

--- a/theories/applications/category_ext.v
+++ b/theories/applications/category_ext.v
@@ -100,7 +100,8 @@ Lemma comp_separated (X Y Z : obj) (f : ele X -> ele Y) (g : ele Y -> ele Z) :
   separated f -> separated g -> separated (g \o f).
 Proof.
 move: f g.
-move: X Y Z => [X1 X2] [Y1 Y2] [Z1 Z2] f g [/= Hf1 Hf2] [/= Hg1 Hg2]; split=> x.
+move: X Y Z => [X1 X2] [Y1 Y2] [Z1 Z2] f g [/= Hf1 Hf2] [/= Hg1 Hg2].
+split => x; rewrite compE.
 - by case/cid: (Hf1 x)=> y /= ->; case/cid: (Hg1 y)=> z /= ->; exists z.
 - by case/cid: (Hf2 x)=> y /= ->; case/cid: (Hg2 y)=> z /= ->; exists z.
 Qed.

--- a/theories/applications/example_elgot.v
+++ b/theories/applications/example_elgot.v
@@ -3,7 +3,7 @@
 Require Import Lia.
 From mathcomp Require Import all_ssreflect.
 From mathcomp Require boolp.
-Require Import hierarchy.
+Require Import preamble hierarchy.
 
 (**md**************************************************************************)
 (* # Applications of the Elgot monad                                          *)
@@ -108,9 +108,9 @@ Proof.
 rewrite /collatz naturalitywB/=.
 apply: whilewB => q.
 have [->|q1] := eqVneq q 1.
-  by rewrite bindretf/= fmapE bindretf.
+  by rewrite bindretf/= compE fmapE bindretf.
 rewrite /collatz_body (negbTE q1).
-by case: ifPn; rewrite bindretf/= fmapE bindretf.
+by case: ifPn; rewrite bindretf/= compE fmapE bindretf.
 Qed.
 
 End collatz.
@@ -137,8 +137,8 @@ Proof.
 rewrite /minus1 /minus2 -codiagonalwB.
 apply: whilewB => -[n m].
 case: n => [|n /=].
-  by case: m => //= [|n]; rewrite fmapE bindretf.
-by rewrite fmapE bindretf.
+  by case: m => //= [|n]; rewrite compE fmapE bindretf.
+by rewrite compE fmapE bindretf.
 Qed.
 
 End minus.
@@ -386,9 +386,9 @@ apply: pcorrect.
 move=> l' /= Inv.
 rewrite /bubblesort_body.
 case: ifP => /eqP H.
-  by rewrite bindretf/= bindretf/= assertE/= Inv guardT bindretf.
+  by rewrite bindretf/= bindretf/= compE assertE/= Inv guardT bindretf.
 move: Inv.
-rewrite !bindretf/= !/sizelE (sortl_length l') /assert /guard.
+rewrite !bindretf/= !/sizelE (sortl_length l') /assert /guard compE.
 case: ifP => //=.
 by rewrite !bindskipf.
 Qed.
@@ -461,16 +461,16 @@ Lemma collatz_state1wB n : collatz_state1 n ≈ collatz_state2 n.
 Proof.
 rewrite /collatz_state1 /collatz_state2 -codiagonalwB.
 apply: whilewB => -[[n' m] l].
-rewrite /collatz_state1_body /collatz_state2_body.
+rewrite /collatz_state1_body /collatz_state2_body compE.
 have [Hl|?] := eqVneq (l %% 4) 1 => /=.
   have [?|] := eqVneq n' 1 => /=.
-    rewrite Hl fmapE bindA.
+    rewrite fmapE bindA/=.
     by under eq_bind do rewrite bindA bindretf.
   have [|] := eqVneq (n' %% 2) 0 => /=;
   rewrite fmapE/= bindA bindfwB//= => a;
   by rewrite bindA bindretf.
 have [Hn'|_] := eqVneq n' 1 => /=.
-  rewrite Hn' ifN //= fmapE bindA.
+  rewrite Hn' fmapE bindA.
   by under eq_bind do rewrite bindA bindA bindretf.
 have [|] := eqVneq (n' %% 2) 0 => /=;
   rewrite fmapE/= bindA;

--- a/theories/applications/example_iquicksort.v
+++ b/theories/applications/example_iquicksort.v
@@ -109,10 +109,10 @@ elim: s p a b => [p a b|h t ih p a b /=]; first by exists (ndRet (a, b)).
 case: ifPn => hp.
   have [syn synE] := @qperm_isNondet M _ b.
   exists (ndBind syn (fun zs' => sval (ih p (rcons a h) zs'))) => /=.
-  by rewrite synE /=; bind_ext =>  ? /=; case: ih.
+  by rewrite synE /=; bind_ext =>  ? /=; rewrite compE; case: ih.
 have [syn synE] := @qperm_isNondet M _ (rcons b h).
 exists (ndBind syn (fun zs' => sval (ih p a zs'))) => /=.
-by rewrite synE /=; bind_ext => ? /=; case: ih.
+by rewrite synE /=; bind_ext => ? /=; rewrite compE; case: ih.
 Qed.
 
 Lemma qperm_partl_cons (p x : E) (ys zs xs : seq E) :

--- a/theories/applications/example_nqueens.v
+++ b/theories/applications/example_nqueens.v
@@ -351,10 +351,10 @@ Proof.
 move=> s; elim: s i a b => // h t IH i a b.
 rewrite /safeAcc_scanl /=.
 move: (IH i.+1 ((Posz i + h) :: a) ((Posz i - h) :: b))%Z.
-rewrite (_ : Posz i.+1 = (Posz i) + 1)%Z; last by rewrite -addn1.  
-rewrite /safeAcc_scanl => /= <-.
+rewrite (_ : Posz i.+1 = (Posz i) + 1)%Z; last by rewrite -addn1.
+rewrite /safeAcc_scanl !compE => /= <-.
 rewrite /safeAcc /= !andbA /zipWith /=.
-set A := uniq _. set B := uniq _. set sa := map _ _. set sb := map _ _.
+set A := uniq _; set B := uniq _; set sa := map _ _; set sb := map _ _.
 rewrite -![in LHS]andbA [in LHS]andbC.
 do 2 rewrite -![in RHS]andbA [in RHS]andbC.
 rewrite -!andbA; congr andb.
@@ -436,7 +436,7 @@ Lemma base_case y : p y -> (unfoldM p select >=> foldr op (Ret [::])) y = Ret [:
 Proof.
 move=> py.
 transitivity (Ret [::] >>= foldr op (Ret [::])).
-  rewrite /kleisli bindretf /= join_fmap unfoldME; last exact: decr_size_select.
+  rewrite /kleisli bindretf !compE/= join_fmap unfoldME; last exact: decr_size_select.
   by rewrite py bindretf.
 by rewrite bindretf.
 Qed.
@@ -449,12 +449,12 @@ apply: (well_founded_induction (@well_founded_size _)) => y IH.
 rewrite hyloME; last exact: decr_size_select.
 case/boolP : (p y) => py.
   by rewrite base_case.
-rewrite /kleisli /= join_fmap.
+rewrite /kleisli !compE/= join_fmap.
 rewrite unfoldME; last exact: decr_size_select.
 rewrite (negbTE py) bindA.
 rewrite(@decr_size_select _ _) /bassert !bindA; bind_ext => -[b a] /=.
 case: assertPn => ay; last by rewrite !bindfailf.
-rewrite !bindretf /= -IH // bind_fmap /kleisli /= join_fmap.
+rewrite !bindretf /= -IH // bind_fmap /kleisli !compE/= join_fmap.
 suff : do x <- unfoldM p select a; op b (foldr op (Ret [::]) x) =
   op b (do x <- unfoldM p select a; foldr op (Ret [::]) x) by [].
 rewrite {ay}.
@@ -527,7 +527,7 @@ Lemma queensBodyE : queensBody M =
 Proof.
 rewrite /queensBody boolp.funeqE => -[|h t].
 - rewrite /= permsE /= hyloME ?bindretf //; exact: decr_size_select.
-- by rewrite [h :: t]lock -theorem51 /kleisli /= join_fmap perms_uperm.
+- by rewrite [h :: t]lock -theorem51 /kleisli !compE/= join_fmap perms_uperm.
 Qed.
 
 Local Open Scope mprog.

--- a/theories/applications/example_quicksort.v
+++ b/theories/applications/example_quicksort.v
@@ -119,7 +119,7 @@ apply: (@refin_trans _ _ (splits xs >>=
   rewrite bindretf; exact: refin_refl.
 under eq_bind do rewrite -bindA -assertE.
 rewrite -bindA; apply: (refin_trans _ (refin_bindr _ (ih _))).
-rewrite bindretf; case: ifPn => ?; exact: refin_refl.
+rewrite !compE/= bindretf; case: ifPn => ?; exact: refin_refl.
 Qed.
 
 End partition.
@@ -182,7 +182,7 @@ exists (ndBind syn (fun a => ndBind
   (if sorted a then ndRet tt else ndFail unit)
   (fun _ : unit => ndRet a))).
 rewrite /= syn_qperm; bind_ext => s' /=.
-case: ifPn => sorteds'.
+rewrite !compE/=; case: ifPn => sorteds'.
   by rewrite /= bindretf assertE sorteds' guardT bindskipf.
 by rewrite /= assertE (negbTE sorteds') guardF bindfailf.
 Qed.
@@ -294,6 +294,7 @@ Qed.
 Lemma qsort_spec : Ret \o qsort `<.=` (@slowsort M _ _).
 Proof.
 move=> s /=.
+rewrite !compE/=.
 apply qsort_elim => [|h t ihys ihzs].
   rewrite slowsort_nil; exact: refin_refl.
 apply: (refin_trans _ (partition_slowsort_spec _)).

--- a/theories/applications/example_relabeling.v
+++ b/theories/applications/example_relabeling.v
@@ -131,7 +131,7 @@ rewrite /=.
 rewrite 2![in RHS]joinE.
 rewrite 3!bindA.
 rewrite -H.
-rewrite !fmapE.
+rewrite !compE !fmapE.
 rewrite 3!bindA.
 bind_ext => {}x1.
 rewrite 2!bindretf 2!bindA.

--- a/theories/applications/example_spark.v
+++ b/theories/applications/example_spark.v
@@ -57,7 +57,7 @@ rewrite insert_rcons.
 rewrite alt_fmapDr fmapE bindretf.
 rewrite -fmap_oE.
 have H : forall w, foldl op b \o rcons^~ w = op^~ w \o foldl op b.
-  by move=> w; rewrite boolp.funeqE => ws /=; rewrite -cats1 foldl_cat.
+  by move=> w; rewrite boolp.funeqE => ws /=; rewrite compE -cats1 foldl_cat.
 rewrite (H y).
 rewrite fmap_oE.
 rewrite fcompE in IH.
@@ -68,7 +68,7 @@ rewrite -{1}compA.
 rewrite fmapE bindretf.
 rewrite (H a).
 rewrite [in X in _ [~] X]/=.
-rewrite opP.
+rewrite !compE opP.
 rewrite /= -!cats1 -catA /=.
 rewrite foldl_cat /=.
 by rewrite altmm.
@@ -95,7 +95,7 @@ rewrite -IH.
 rewrite [in RHS]fcompE.
 rewrite fmapE.
 bind_ext => ys.
-rewrite /= -cats1 foldl_cat /=.
+rewrite !compE/= -cats1 foldl_cat /=.
 congr (Ret _ : M _).
 elim: ys b opP' => // y ys ih /= b opP'.
 rewrite ih //=.

--- a/theories/applications/example_transformer.v
+++ b/theories/applications/example_transformer.v
@@ -189,7 +189,7 @@ Lemma bindLmfail (M := [the monad of option_monad]) S T U (m : stateT S M U)
 Proof.
 rewrite /= /liftS; apply: boolp.funext => s.
 rewrite except_bindE.
-rewrite {1}bindE /= MS_mapE {1}/bindS /=.
+rewrite {1}bindE /= MS_mapE {1}/bindS compE/=.
 by case (m s) => // -[].
 Qed.
 

--- a/theories/applications/monad_composition.v
+++ b/theories/applications/monad_composition.v
@@ -69,7 +69,7 @@ Proof.
 move=> A; rewrite /JOIN'.
 rewrite /=.
 rewrite /CRet.
-rewrite compA.
+rewrite (compA JOIN).
 rewrite -(compA Join (M # prod) Ret) (natural ret).
 by rewrite [LHS]compA (compA Join) joinretM compidf Hprod2.
 Qed.
@@ -78,7 +78,8 @@ Lemma JOIN_fmap_ret : JoinLaws.right_unit (@CRet M N) (@JOIN').
 Proof.
 move=> A.
 rewrite /JOIN' /=.
-rewrite -compA.
+rewrite -(compA Join).
+rewrite -[LHS]compA.
 rewrite FCompE.
 rewrite -(@functor_o M).
 by rewrite Hprod3 joinMret.
@@ -87,14 +88,14 @@ Qed.
 Lemma JOIN_fmap_JOIN : JoinLaws.associativity (@JOIN').
 Proof.
 move=> A; rewrite {1 2}/JOIN' -[LHS]compA /=.
-rewrite -functor_o.
+rewrite -(@functor_o M).
 rewrite Hprod4.
 rewrite {1}/JOIN.
 rewrite -(compA Join (M # prod) prod).
 rewrite functor_o.
 rewrite [LHS]compA.
 rewrite joinA.
-rewrite -compA.
+rewrite -(compA Join).
 rewrite functor_o.
 rewrite (compA Join (M # (M # prod)) (M # prod)).
 by rewrite -(natural _).

--- a/theories/core/category.v
+++ b/theories/core/category.v
@@ -499,7 +499,7 @@ Proof.
 apply nattrans_ext => c /=.
 rewrite compidf compfid [in LHS]HCompE [in RHS]HCompE.
 rewrite [in LHS]HCompE hom_compA -functor_o; congr [\o _, _].
-by congr (_ # _); apply hom_ext; rewrite HCompE.
+by congr (F'' # _); apply hom_ext; rewrite HCompE.
 Qed.
 Lemma HCompA c : ((u \h t) \h s) c = (u \h (t \h s)) c.
 Proof. by rewrite hom_ext HCompA_def. Qed.
@@ -532,7 +532,8 @@ Variables (s' : G ~> H) (t' : G' ~> H').
 Lemma HCompACA : (t' \h s') \v (t \h s) = (t' \v t) \h (s' \v s).
 Proof.
 apply nattrans_ext => c /=.
-rewrite !HCompE !VCompE -compA -[in RHS]compA; congr (_ \o _).
+rewrite 3!HCompE VCompE VCompE_nat functor_o.
+rewrite -[in LHS]compA -[in RHS]compA; congr (_ \o _).
 by rewrite natural_head -functor_o.
 Qed.
 End hcomp_lemmas.
@@ -851,7 +852,7 @@ Qed.
 Let fmap_o : FunctorLaws.comp fmap.
 Proof.
 move=> a b c g h; apply/hom_ext/funext=>m; rewrite /fmap/=.
-rewrite bindA/=.
+rewrite compE bindA/=.
 congr (fun f => bind f m); rewrite hom_ext/=.
 by rewrite -[in RHS]hom_compA bindretf_fun.
 Qed.
@@ -870,7 +871,7 @@ Let join'_naturality : naturality (F \O F) F join'.
 Proof.
 move => A B h.
 rewrite /join /= funeqE => m /=.
-rewrite fmap_bind bindA /=.
+rewrite compE fmap_bind compE bindA /=.
 congr (fun f => bind f m).
 rewrite hom_ext/=.
 rewrite -[in RHS]hom_compA.
@@ -908,8 +909,9 @@ Qed.
 Lemma joinA : JoinLaws.associativity join.
 Proof.
 move => A; rewrite funeqE => mmma.
-rewrite /join.
-rewrite bind_fmap_fun/= bindA/=.
+rewrite /join/=/join'/=.
+rewrite [X in X _ = _]bind_fmap_fun.
+rewrite [in RHS]compE bindA.
 congr (fun f => bind f mmma).
 by rewrite hom_ext.
 Qed.
@@ -953,9 +955,9 @@ Proof. by move=> a; rewrite joinE triR. Qed.
 Lemma join_right_unit : JoinLaws.right_unit ret join.
 Proof.
 move=> a; rewrite joinE. rewrite /M FCompE.
-rewrite /= -functor_o -[in RHS]functor_id.
+rewrite -(functor_o G) -[in RHS]functor_id.
 congr (G # _).
-by rewrite hom_ext/= triL.
+by rewrite hom_ext/= triL functor_id.
 Qed.
 (*TODO: make this go through
 HB.instance Definition _ :=

--- a/theories/core/hierarchy.v
+++ b/theories/core/hierarchy.v
@@ -510,7 +510,7 @@ Let actm_comp : FunctorLaws.comp actm.
 Proof.
 move=> a b c g h.
 rewrite /actm; apply: boolp.funext => m /=.
-rewrite bindA.
+rewrite compE bindA.
 congr bind.
 apply: boolp.funext => u /=.
 by rewrite bindretf.
@@ -524,7 +524,7 @@ Let ret_naturality : naturality idfun F ret.
 Proof.
 move=> a b h.
 rewrite FIdE /hierarchy.actm /= /actm; apply: boolp.funext => m /=.
-by rewrite bindretf.
+by rewrite compE bindretf.
 Qed.
 
 HB.instance Definition _ :=
@@ -541,7 +541,7 @@ Proof.
 move=> a b h.
 rewrite /join' /=; apply: boolp.funext => mm /=.
 rewrite /hierarchy.actm /= /isFunctor.actm /=.
-rewrite actm_bind bindA /=.
+rewrite !compE actm_bind bindA.
 congr bind.
 apply: boolp.funext => m /=.
 by rewrite bindretf /=.
@@ -567,7 +567,7 @@ Qed.
 Let joinretM : JoinLaws.left_unit ret join.
 Proof.
 move=> a; apply: boolp.funext => m.
-by rewrite /join /= /join' /= bindretf.
+by rewrite /join /= /join' /= compE bindretf.
 Qed.
 
 Let joinMret : JoinLaws.right_unit ret join.
@@ -575,7 +575,7 @@ Proof.
 move=> a; apply: boolp.funext => m.
 rewrite /join /= /join'.
 rewrite /hierarchy.actm /= /actm /=.
-rewrite bindA /=.
+rewrite compE bindA /=.
 rewrite [X in bind m X](_ : _ = fun x => ret x) ?bindmret //=; apply: boolp.funext => ?.
 by rewrite bindretf.
 Qed.
@@ -585,7 +585,7 @@ Proof.
 move => a; apply: boolp.funext => m.
 rewrite /join /= /join'.
 rewrite /hierarchy.actm /= /actm.
-rewrite !bindA.
+rewrite compE [in RHS]compE !bindA.
 congr bind.
 apply: boolp.funext => u /=.
 by rewrite bindretf.
@@ -696,7 +696,7 @@ Proof. by []. Qed.
 
 Lemma kleisliE A B C (g : B -> M C) (f : A -> M B) (a : A) :
   (f >=> g) a = (f a) >>= g.
-Proof. by rewrite /kleisli /= join_fmap. Qed.
+Proof. by rewrite /kleisli !compE join_fmap. Qed.
 
 Lemma bind_kleisli A B C m (f : A -> M B) (g : B -> M C) :
   m >>= (f >=> g) = (m >>= f) >>= g.

--- a/theories/core/monad_transformer.v
+++ b/theories/core/monad_transformer.v
@@ -77,7 +77,7 @@ HB.builders Context (M N : monad) (e : M ~~> N) of isMonadM_ret_bind M N e.
 Lemma naturality_monadM : naturality M N e.
 Proof.
 move=> A B h; apply boolp.funext => m /=.
-by rewrite !fmapE monadMbind (compA (e B)) monadMret.
+by rewrite !compE !fmapE monadMbind (compA (e B)) monadMret.
 Qed.
 
 HB.instance Definition _ := isNatural.Build M N e naturality_monadM.
@@ -124,7 +124,7 @@ Lemma MS_mapE (A B : UU0) (f : A -> B) (m : MS A) :
   ([the functor of MS] # f) m = (M # (fun x => (f x.1, x.2))) \o m.
 Proof.
 apply boolp.funext=> s.
-rewrite {1}/actm /= /bindS /= fmapE.
+rewrite {1}/actm /= /bindS compE/= fmapE.
 congr bind.
 by apply: boolp.funext; case.
 Qed.
@@ -135,7 +135,7 @@ Definition liftS (A : UU0) (m : M A) : MS A :=
 Let retliftS : MonadMLaws.ret liftS.
 Proof.
 move=> A; rewrite /liftS; apply: boolp.funext => a /=; apply: boolp.funext => s /=.
-by rewrite bindretf.
+by rewrite compE bindretf.
 Qed.
 
 Let bindliftS : MonadMLaws.bind liftS.
@@ -199,7 +199,7 @@ apply: boolp.funext => s.
 rewrite /Get/=.
 rewrite !bindE !MS_mapE /= /bindS /= /retS/=.
 rewrite !bind_fmap !bindretf/=.
-rewrite !bindE !MS_mapE /= /bindS /= /retS/=.
+rewrite !compE !bindE !MS_mapE /= /bindS /= /retS/=.
 by rewrite bind_fmap bindretf.
 Qed.
 
@@ -251,7 +251,7 @@ Definition liftX X (m : M X) : MX X := m >>= (@ret [the monad of MX] _).
 
 Let retliftX : MonadMLaws.ret liftX.
 Proof.
-by move=> A; apply: boolp.funext => a; rewrite /liftX /= bindretf.
+by move=> A; apply: boolp.funext => a; rewrite /liftX compE/= bindretf.
 Qed.
 
 Let bindliftX : MonadMLaws.bind liftX.
@@ -262,7 +262,7 @@ rewrite /= /join_of_bind /bindX /= !bindA.
 rewrite 2!joinE !bindA.
 bind_ext => a.
 rewrite 3!bindretf.
-rewrite /liftX /=.
+rewrite /liftX compE/=.
 bind_ext => b.
 by rewrite bindretf.
 Qed.
@@ -363,7 +363,7 @@ HB.instance Definition _ :=
 
 Lemma MEnv_mapE (A B : UU0) (f : A -> B) (m : MEnv A) :
   (MEnv # f) m = (M # f) \o m.
-Proof. by apply: boolp.funext => r; rewrite /= fmapE. Qed.
+Proof. by apply: boolp.funext => r; rewrite compE/= fmapE. Qed.
 
 Definition liftEnv A (m : M A) : MEnv A := fun r => m.
 
@@ -433,7 +433,7 @@ Definition liftO A (m : M A) : MO A := m >>= (fun x => Ret (x, [::])).
 Let retliftO : MonadMLaws.ret liftO.
 Proof.
 move=> a; rewrite /liftO /= /retO; apply: boolp.funext => o /=.
-by rewrite bindretf.
+by rewrite compE bindretf.
 Qed.
 
 Let bindliftO : MonadMLaws.bind liftO.
@@ -487,7 +487,7 @@ Definition liftC A (x : M A) : MC A := fun k => x >>= k.
 Let retliftC : MonadMLaws.ret liftC.
 Proof.
 move => A; rewrite /liftC; apply: boolp.funext => a /=.
-by apply: boolp.funext => s; rewrite bindretf.
+by apply: boolp.funext => s; rewrite compE bindretf.
 Qed.
 
 Let bindliftC : MonadMLaws.bind liftC.
@@ -670,7 +670,7 @@ transitivity (Join ((M # (Join \o (M # g))) (n (M A) t))); last first.
   apply: boolp.funext => ma.
   by rewrite bindE.
 rewrite -[in X in Join X = _]compE.
-rewrite (natural join).
+rewrite compE natural.
 rewrite functor_o.
 rewrite -[in RHS]FCompE.
 rewrite -[RHS]compE.
@@ -722,6 +722,7 @@ Lemma psiK (op : E ~> M) : phi (psi op) = op.
 Proof.
 apply/nattrans_ext => A.
 rewrite phiE /= psiE; apply: boolp.funext => m /=.
+rewrite !compE.
 rewrite -(compE (op _)) -(natural op) -(compE Join).
 by rewrite compA joinMret.
 Qed.
@@ -731,6 +732,7 @@ Proof.
 apply/aoperation_ext => A.
 rewrite /=.
 rewrite psiE phiE; apply boolp.funext => m /=.
+rewrite !compE.
 rewrite -(compE (op _)) joinE.
 rewrite (algebraic op).
 rewrite -(compE (E # _)) -functor_o.
@@ -849,7 +851,7 @@ Let monadMret_hmapX (F G : monad) (e : monadM F G) :
   MonadMLaws.ret (hmapX' e).
 Proof.
 move=> A; apply: boolp.funext => /= a.
-by rewrite /hmapX' /retX /= -(compE (e _)) monadMret.
+by rewrite /hmapX' /retX !compE/= -(compE (e _)) monadMret.
 Qed.
 
 Let monadMbind_hmapX (F G : monad) (e : monadM F G) :
@@ -860,7 +862,7 @@ rewrite !bindE /= !MX_mapE /bindX /= !bind_fmap.
 rewrite !monadMbind /=.
 congr (bind (e (X + A)%type m) _).
 apply boolp.funext => -[x/=|//].
-by rewrite -(compE (e _)) monadMret.
+by rewrite !compE/= -(compE (e _)) monadMret.
 Qed.
 
 Let hmapX_lift :
@@ -874,10 +876,10 @@ rewrite /liftX /=.
 rewrite /retX /=.
 apply: boolp.funext => ma /=.
 rewrite (_ : (fun x : A => Ret (inr x)) = Ret \o inr) //.
-rewrite -bind_fmap.
+rewrite compE -bind_fmap.
 rewrite bindmret.
 rewrite (_ : (fun x : A => Ret (inr x)) = Ret \o inr) //.
-rewrite -bind_fmap.
+rewrite compE -bind_fmap.
 rewrite bindmret.
 rewrite -(compE (N # inr)).
 by rewrite (natural t).
@@ -902,10 +904,9 @@ rewrite /hmapS /=.
 have H : forall G, [the monad of stateT S G] # h = [the functor of MS S G] # h by [].
 rewrite !H {H}.
 apply: boolp.funext => m /=.
-rewrite !MS_mapE.
+rewrite !compE !MS_mapE.
 apply: boolp.funext => s /=.
-rewrite -(compE  _ (tau (A * S)%type)).
-by rewrite natural.
+by rewrite [in LHS]compE -(compE  _ (tau (A * S)%type)) natural.
 Qed.
 
 HB.instance Definition _ (F G : monad) (tau : F ~> G) := isNatural.Build
@@ -928,7 +929,7 @@ Let monadMret_hmapS (F G : monad) (e : monadM F G) :
 Proof.
 move=> A; apply boolp.funext => /= a.
 rewrite /hmapS /= /retS /=; apply: boolp.funext => s.
-by rewrite [in LHS]curryE monadMret.
+by rewrite compE [in LHS]curryE monadMret.
 Qed.
 
 Let monadMbind_hmapS (F G : monad) (e : monadM F G) :
@@ -950,7 +951,7 @@ rewrite /hmapS /=.
 rewrite /liftS /=.
 apply: boolp.funext => ma /=.
 apply: boolp.funext => s /=.
-rewrite ![in LHS]bindE ![in LHS]fmapE ![in LHS]bindE.
+rewrite !compE ![in LHS]bindE ![in LHS]fmapE ![in LHS]bindE.
 rewrite 2!(_ : (fun x : A => Ret (x, s)) = Ret \o (fun x => (x, s))) //.
 rewrite functor_o.
 rewrite -(compE Join (_ \o _)).
@@ -965,7 +966,7 @@ rewrite -(compE _ (t A)).
 rewrite -(compE (t _)).
 rewrite -natural.
 rewrite /=.
-rewrite ![in RHS]bindE ![in RHS]fmapE ![in RHS]bindE.
+rewrite !compE ![in RHS]bindE ![in RHS]fmapE ![in RHS]bindE.
 rewrite functor_o.
 rewrite -(compE Join (_ \o _)).
 rewrite (compA Join (N # _)).
@@ -998,9 +999,9 @@ rewrite /=.
 have H : forall G, [the monad of envT E G] # h = [the functor of MEnv E G] # h by [].
 rewrite !H {H}.
 apply: boolp.funext => m /=.
-rewrite !MEnv_mapE.
+rewrite !compE !MEnv_mapE.
 apply: boolp.funext => s /=.
-rewrite -(compE  _ (tau A)).
+rewrite !compE -(compE  _ (tau A)).
 by rewrite natural.
 Qed.
 
@@ -1062,7 +1063,7 @@ rewrite /hmapO.
 rewrite /=.
 have H : forall G, [the monad of outputT R G] # h = [the functor of MO R G] # h by [].
 rewrite !H {H}.
-apply boolp.funext => m /=; rewrite !MO_mapE.
+apply boolp.funext => m /=; rewrite !compE !MO_mapE.
 rewrite -[in LHS](compE  _ (tau _)).
 by rewrite natural.
 Qed.
@@ -1096,7 +1097,7 @@ rewrite 2!bindE /= !MO_mapE /bindO /= 2!bind_fmap.
 rewrite !monadMbind.
 bind_ext => -[x w].
 rewrite /retO /=.
-rewrite monadMbind.
+rewrite !compE monadMbind.
 bind_ext => /= -[h t] /=.
 rewrite -[LHS](compE _ Ret (h, _)).
 by rewrite monadMret.
@@ -1110,7 +1111,7 @@ Proof.
 move=> h M N t; apply/nattrans_ext => A /=; rewrite !vcompE/=.
 rewrite /hmapO /= /liftO /=.
 apply: boolp.funext => ma /=.
-rewrite -!fmapE.
+rewrite !compE -!fmapE.
 rewrite -(compE _ (t A)).
 by rewrite natural.
 Qed.

--- a/theories/core/preamble.v
+++ b/theories/core/preamble.v
@@ -22,7 +22,7 @@ Arguments ssrfun.comp {A B C} : simpl never.
 (*         curry/uncurry == currying for pairs                                *)
 (*       curry3/uncurry3 == currying for triples                              *)
 (*        comparePc/eqPc == computable version of equality axioms             *)
-(*  coerce T1 (v : f T1) == some (f T2) if T1 = T2 and None o.w.              *)
+(*  coerce T1 (v : f T1) == Some (f T2) if T1 = T2 and None o.w.              *)
 (* ```                                                                        *)
 (*                                                                            *)
 (******************************************************************************)

--- a/theories/core/preamble.v
+++ b/theories/core/preamble.v
@@ -12,6 +12,8 @@ Definition eq_rect_eq :=
 
 Definition funext_dep := boolp.functional_extensionality_dep.
 
+Arguments ssrfun.comp {A B C} : simpl never.
+
 (**md**************************************************************************)
 (* # Shared notations and easy definitions/lemmas of general interest         *)
 (*                                                                            *)
@@ -28,6 +30,9 @@ Definition funext_dep := boolp.functional_extensionality_dep.
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
+
+Lemma compE A B C (g : B -> C) (f : A -> B) a : (g \o f) a = g (f a).
+Proof. by []. Qed.
 
 (* notations common to hierarchy.v and category.v *)
 
@@ -92,7 +97,7 @@ Variables (U : Type) (h : U -> R) (w : U) (g : T -> U -> U).
 Hypothesis H1 : h w = r.
 Hypothesis H2 : forall x y, h (g x y) = f x (h y).
 Lemma foldr_fusion : h \o foldr g w = foldr f r.
-Proof. by apply boolp.funext; elim => // a b /= ih; rewrite H2 ih. Qed.
+Proof. by apply boolp.funext; elim => // a b /= <-; rewrite compE H2. Qed.
 Lemma foldr_fusion_ext x : (h \o foldr g w) x = foldr f r x.
 Proof. by rewrite -foldr_fusion. Qed.
 End fusion_law.
@@ -150,9 +155,6 @@ Proof. by []. Qed.
 Lemma compfid A B (f : A -> B) : f \o id = f. Proof. by []. Qed.
 
 Lemma compidf A B (f : A -> B) : id \o f = f. Proof. by []. Qed.
-
-Lemma compE A B C (g : B -> C) (f : A -> B) a : (g \o f) a = g (f a).
-Proof. by []. Qed.
 
 Lemma if_pair A B b (x : A) y (u : A) (v : B) :
   (if b then (x, y) else (u, v)) = (if b then x else u, if b then y else v).

--- a/theories/lib/alt_lib.v
+++ b/theories/lib/alt_lib.v
@@ -114,9 +114,9 @@ Lemma arbitrary_cons (T : UU0) (def : T) h t : 0 < size t ->
 Proof.
 move: def h; elim: t => // a [//|b [|c t]] ih def h _.
 - by rewrite arbitrary2.
-- by rewrite /arbitrary /= altA altC (altC (Ret b)).
-- move: (ih a h erefl); rewrite /arbitrary /= => ->.
-  move: (ih h a erefl); rewrite /arbitrary /= => ->.
+- by rewrite /arbitrary !compE /= altA altC (altC (Ret b)).
+- move: (ih a h erefl); rewrite /arbitrary !compE /= => ->.
+  move: (ih h a erefl); rewrite /arbitrary !compE /= => ->.
   by rewrite altCA.
 Qed.
 
@@ -127,7 +127,7 @@ Lemma arbitrary_naturality (T U : UU0) (a : T) (b : U) (f : T -> U) :
 Proof.
 elim=> // x [_ _ | x' xs /(_ isT)].
   by rewrite [in LHS]compE fmapE bindretf.
-rewrite [in X in X -> _]/= fmapE => ih _.
+rewrite [in X in X -> _]/= compE fmapE => ih _.
 rewrite [in RHS]compE [in RHS]/= [in RHS](arbitrary_cons b) // [in LHS]compE.
 by rewrite [in LHS]arbitrary_cons // fmapE /= alt_bindDl bindretf /= ih.
 Qed.
@@ -318,7 +318,7 @@ rewrite fcompE insertE alt_fmapDr.
 rewrite -(compE (fmap (map f))) (natural ret) FIdE [in X in X [~] _ ]/=.
 (* second branch *)
 rewrite -fmap_oE (_ : map f \o cons y = cons (f y) \o map f) //.
-by rewrite fmap_oE -(fcompE (map f)) -IH [RHS]/= insertE.
+by rewrite fmap_oE -(fcompE (map f)) -IH [RHS]compE insertE.
 Qed.
 
 Hypothesis Mmm : forall A, idempotent_op (@alt _ A : M A -> M A -> M A).
@@ -329,39 +329,42 @@ Lemma filter_insertN a : ~~ p a ->
   forall s, (filter p (o) insert a) s = Ret (filter p s) :> M _.
 Proof.
 move=> pa; elim => [|h t IH].
-  by rewrite fcompE insertE -(compE (fmap _)) (natural ret) FIdE /= (negbTE pa).
+  rewrite fcompE insertE -(compE (fmap _)) (natural ret) FIdE.
+  by rewrite compE/= (negbTE pa).
 rewrite fcompE insertE alt_fmapDr.
-rewrite -(compE (fmap _)) (natural ret) FIdE [in X in X [~] _]/= (negbTE pa).
+rewrite -(compE (fmap _)) (natural ret) FIdE.
+rewrite [in X in X [~] _]compE/= (negbTE pa).
 case: ifPn => ph.
 - rewrite -fmap_oE (_ : filter p \o cons h = cons h \o filter p); last first.
-    by apply boolp.funext => x /=; rewrite ph.
+    by apply boolp.funext => x /=; rewrite !compE/= ph.
   rewrite fmap_oE.
   move: (IH); rewrite fcompE => ->.
-  by rewrite fmapE /= ph bindretf /= Mmm.
+  by rewrite fmapE bindretf compE Mmm.
 - rewrite -fmap_oE (_ : filter p \o cons h = filter p); last first.
-    by apply boolp.funext => x /=; rewrite (negbTE ph).
-  by move: (IH); rewrite fcompE => -> /=; rewrite (negbTE ph) Mmm.
+    by apply boolp.funext => x /=; rewrite compE/= (negbTE ph).
+  by move: (IH); rewrite fcompE => ->; rewrite Mmm.
 Qed.
 
 Lemma filter_insertT a : p a ->
   filter p (o) insert a = insert a \o filter p :> (_ -> M _).
 Proof.
 move=> pa; apply boolp.funext; elim => [|h t IH].
-  by rewrite fcompE !insertE fmapE bindretf /= pa.
-rewrite fcompE [in RHS]/=; case: ifPn => ph.
+  by rewrite fcompE !insertE fmapE bindretf compE/= pa.
+rewrite fcompE compE [in RHS]/=; case: ifPn => ph.
 - rewrite [in RHS]insertE.
-  move: (IH); rewrite [in X in X -> _]/= => <-.
+  move: (IH); rewrite compE [in X in X -> _]/= => <-.
   rewrite [in LHS]insertE alt_fmapDr; congr (_ [~] _).
-    by rewrite fmapE bindretf /= pa ph.
+    by rewrite fmapE bindretf compE/= pa ph.
   rewrite !fmapE /= fcompE bind_fmap bindA.
-  under [LHS]eq_bind do rewrite bindretf.
+  under [LHS]eq_bind do rewrite bindretf compE.
   by rewrite /= ph.
 - rewrite [in LHS]insertE alt_fmapDr.
   rewrite -[in X in _ [~] X = _]fmap_oE.
   rewrite (_ : (filter p \o cons h) = filter p); last first.
-    by apply boolp.funext => x /=; rewrite (negbTE ph).
+    by apply boolp.funext => x /=; rewrite compE/= (negbTE ph).
   move: (IH); rewrite fcompE => ->.
-  rewrite fmapE bindretf /= pa (negbTE ph) [in RHS]insertE; case: (filter _ _) => [|h' t'].
+  rewrite fmapE bindretf !compE/= pa (negbTE ph) [in RHS]insertE.
+  case: (filter _ _) => [|h' t'].
     by rewrite insertE Mmm.
   by rewrite !insertE altA Mmm.
 Qed.
@@ -392,9 +395,10 @@ apply boolp.funext; elim => [|h t ih].
   by rewrite fcompE insertE fmapE bindretf.
 rewrite fcompE insertE compE alt_fmapDr fmapE bindretf compE [in RHS]rev_cons.
 rewrite insert_rcons rev_cons -cats1 rev_cons -cats1 -catA; congr (_ [~] _).
-move: ih; rewrite fcompE [X in X -> _]/= => <-.
-rewrite -!fmap_oE. congr (fmap _ (insert a t)).
-by apply boolp.funext => s; rewrite /= -rev_cons.
+move: ih; rewrite fcompE compE [X in X -> _]/= => <-.
+rewrite -!fmap_oE.
+congr (fmap _ (insert a t)).
+by apply boolp.funext => s; rewrite !compE/= -rev_cons.
 Qed.
 
 End insert_altCIMonad.
@@ -422,7 +426,7 @@ Variables (A : UU0) (p : pred A).
 (* netys2017 *)
 Lemma iperm_filter : iperm \o filter p = filter p (o) iperm :> (_ -> M _).
 Proof.
-apply boolp.funext; elim => [|h t /= IH].
+apply boolp.funext; elim => [|h t /[!compE] /= IH].
   by rewrite fcompE fmapE bindretf.
 case: ifPn => ph.
   rewrite [in LHS]/= IH [in LHS]fcomp_def compE [in LHS]bind_fmap.

--- a/theories/lib/fail_lib.v
+++ b/theories/lib/fail_lib.v
@@ -383,6 +383,7 @@ Lemma decr_size_select : bassert_size select.
 Proof.
 case => [|h t]; first by rewrite !selectE fmap_fail /bassert bindfailf.
 rewrite /bassert selectE bind_fmap fmapE; bind_ext => -[x y] /=.
+rewrite !compE.
 by case: assertPn => //=; rewrite size_tuple /= ltnS leqnn.
 Qed.
 
@@ -752,7 +753,7 @@ have liftM2_qperm_isNondet (a b : (size t).-bseq A) :
   - by rewrite (leq_ltn_trans (size_bseq b)).
 exists (ndBind syn (fun a => sval (liftM2_qperm_isNondet a.1 a.2))).
 rewrite /= syn_tsplits; bind_ext => -[a b] /=.
-by rewrite bindretf; case: (liftM2_qperm_isNondet _ _).
+by rewrite bindretf compE; case: (liftM2_qperm_isNondet _ _).
 Qed.
 
 End plus_commute.

--- a/theories/lib/monad_lib.v
+++ b/theories/lib/monad_lib.v
@@ -86,7 +86,7 @@ Lemma mfoldl_rev (T R : UU0) (f : R -> T -> R) (z : R)
   foldl f z (o) (rev (o) s) = foldr (fun x => f^~ x) z (o) s.
 Proof.
 apply boolp.funext => x; rewrite !fcompE 3!fmapE !bindA.
-bind_ext => ?; by rewrite bindretf /= -foldl_rev.
+by bind_ext => ?; rewrite bindretf compE foldl_rev.
 Qed.
 Local Close Scope mprog.
 
@@ -589,15 +589,15 @@ apply: (@AdjointFunctor.mk _ _ uni couni).
   rewrite (_ : @eps0 _ \o F0 # _ = @eta (F0 A)).
     exact: (AdjointFunctor.tri_left H).
   rewrite functor_o [LHS]compA -FCompE.
-  rewrite -(natural (AdjointFunctor.eps H0)) /= FIdE -compA.
+  rewrite -(natural (AdjointFunctor.eps H0)) /= FIdE -[LHS]compA.
   by rewrite (AdjointFunctor.tri_left H0) compfid.
 rewrite /TriangularLaws.right => A.
 rewrite /couni /uni /=.
-rewrite compA -[RHS](AdjointFunctor.tri_right H0 (U A)); congr (_ \o _).
-rewrite FCompE -functor_o; congr (_ # _).
-rewrite functor_o -compA -FCompE.
+rewrite [LHS]compA -[RHS](AdjointFunctor.tri_right H0 (U A)); congr (_ \o _).
+rewrite FCompE -(@functor_o U0); congr (_ # _).
+rewrite functor_o -compA.
 rewrite (natural (AdjointFunctor.eta H)) FIdE.
-by rewrite compA (AdjointFunctor.tri_right H) compidf.
+by rewrite [LHS]compA (AdjointFunctor.tri_right H) compidf.
 Qed.
 
 End composite_adjoint.

--- a/theories/lib/state_lib.v
+++ b/theories/lib/state_lib.v
@@ -241,7 +241,7 @@ rewrite [in LHS]/=.
 rewrite Hx size_f /bassert !bindA.
 bind_ext => -[x1 x2].
 case: assertPn; rewrite ltnS => b1b2; last by rewrite !bindfailf.
-rewrite !bindretf /g/=.
+rewrite !bindretf /g compE/=.
 case: Bool.bool_dec => // x2t.
 by case: (IH x2) => // x0 <-; rewrite fmapE.
 Qed.
@@ -454,7 +454,7 @@ case: assertPn => ps; last first.
   rewrite bindfailf.
   With (idtac) Open (X in _ >>= X).
     rewrite /assert; unlock => /=.
-    rewrite (negbTE (segment_closed_suffix ps x)) guardF bindfailf.
+    rewrite compE (negbTE (segment_closed_suffix ps x)) guardF bindfailf.
     reflexivity.
   by rewrite right_z.
 rewrite bindretf bindA /=.
@@ -462,9 +462,9 @@ under [RHS]eq_bind do rewrite bindretf.
 rewrite bindA.
 bind_ext => t.
 case: (assertPn _ _ t) => pt; last first.
-  rewrite bindfailf assertE (negbTE (segment_closed_prefix pt s)) guardF.
+  rewrite bindfailf compE assertE (negbTE (segment_closed_prefix pt s)) guardF.
   by rewrite bindfailf.
-by rewrite bindretf /=  2!assertE promotable_pq //= bindA bindretf.
+by rewrite bindretf compE/= 2!assertE promotable_pq //= bindA bindretf.
 Qed.
 
 Section examples_promotable_segment_closed.
@@ -601,7 +601,7 @@ rewrite putget.
 rewrite bindA.
 rewrite bindretf.
 rewrite putput.
-by rewrite /= addSnnS.
+by rewrite compE/= addSnnS.
 Qed.
 
 End tick_fusion.

--- a/theories/models/delay_model.v
+++ b/theories/models/delay_model.v
@@ -3,7 +3,7 @@
 From mathcomp Require Import all_ssreflect.
 From mathcomp Require boolp.
 From HB Require Import structures.
-Require Import hierarchy monad_lib Morphisms.
+Require Import preamble hierarchy monad_lib Morphisms.
 
 (**md**************************************************************************)
 (* # Model of the Delay monad                                                 *)
@@ -689,7 +689,7 @@ CoFixpoint naturalitywB' {A B C} (f : A -> M (B + A)) (g : B -> M C) (d : M (B +
 Proof.
 case: d => [[b|a]|d].
 - apply wBisims_wBisim.
-  rewrite !bindretf /= fmapE bindA.
+  rewrite !bindretf/= compE fmapE bindA.
   have [[c Ht]|/Diverge_spinP HD] := StopP (g b).
     set h := fun x => (Ret \o inl) x >>= _.
     rewrite (Stop_bindmf h Ht).
@@ -699,7 +699,7 @@ case: d => [[b|a]|d].
   rewrite HD.
   setoid_symmetry.
   exact/Diverge_wBisims_spinP/Diverge_bindspinf.
-- rewrite! bindretf /= fmapE bindA bindretf /= bindretf /= bind_Later.
+- rewrite! bindretf /= compE fmapE bindA bindretf /= bindretf /= bind_Later.
   apply wBLater.
   rewrite whileE whileE.
   exact: naturalitywB'.
@@ -735,9 +735,11 @@ CoFixpoint codiagonalwB' {A B} (f: A -> M ((B + A) + A))(d: M ((B + A) + A)) :
 Proof.
 case: d => [ [[b|a]|a]|d'].
 - by rewrite bindretf bindretf bindretf //= bindretf.
-- rewrite bindretf bindretf bindretf //= bindretf whileE whileE whileE //= fmapE.
+- rewrite bindretf bindretf bindretf //= bindretf whileE whileE whileE //=.
+  rewrite compE fmapE.
   exact/wBLater/codiagonalwB'.
-- rewrite bindretf bindretf bindretf //= bind_Later whileE whileE //= fmapE.
+- rewrite bindretf bindretf bindretf //= bind_Later whileE whileE //=.
+  rewrite compE fmapE.
   exact/wBLater/codiagonalwB'.
 - by rewrite !bind_Later; exact/wBLater/codiagonalwB'.
 Qed.
@@ -746,7 +748,9 @@ Lemma codiagonalwB {A B} (f : A -> M ((B + A) + A)) a :
   while ((Delay # ((sum_rect (fun => (B + A)%type) idfun inr))) \o f) a
   ≈
   while (while f) a.
-Proof. by rewrite whileE whileE whileE //= fmapE; exact: codiagonalwB'. Qed.
+Proof.
+by rewrite whileE whileE whileE //= compE fmapE; exact: codiagonalwB'.
+Qed.
 
 Lemma whilewB {A B} (f g : A -> M (B + A)) (a : A) :
   (forall a, f a ≈ g a) -> while f a ≈ while g a.
@@ -815,7 +819,7 @@ case: (StopP (while g c)).
     exists n2.
     rewrite /gch -(addn0 n2).
     apply: (steps_bindD Hg).
-    by case a => a' /= ; rewrite fmapE bindretf.
+    by case: a Hg Ha => a' Hg Ha /=; rewrite !compE fmapE bindretf.
   move/(Stop_wBisim Tgch).
   clear gch Tgch.
   case/Stop_steps => n1 Tfhc.
@@ -850,12 +854,12 @@ move: (H c).
 move/(Stop_wBisim Tfhc).
 case/Stop_steps => n1 Tgc.
 have [[b'|a'] [n3] [] /= Hgc] := steps_bind Tgc.
-  rewrite fmapE bindretf /= steps_Now => -[] Hb'.
+  rewrite compE fmapE bindretf /= steps_Now => -[] Hb'.
   exists b'.
   apply/Stop_steps.
   exists (n3 + 0).
   exact: (steps_bindD Hgc).
-rewrite fmapE bindretf /= steps_Now => -[] Hha'.
+rewrite !compE fmapE bindretf /= steps_Now => -[] Hha'.
 rewrite -Hha' in Ha.
 have Hnn2 : n - n2 > 0 by case: (n - n2) Ha.
 rewrite -(prednK Hnn2) /= in Ha.

--- a/theories/models/elgot_model.v
+++ b/theories/models/elgot_model.v
@@ -3,7 +3,7 @@
 From mathcomp Require Import all_ssreflect.
 From mathcomp Require boolp.
 From HB Require Import structures.
-Require Import hierarchy monad_lib fail_lib state_lib trace_lib.
+Require Import preamble hierarchy monad_lib fail_lib state_lib trace_lib.
 Require Import monad_transformer monad_model.
 
 (**md**************************************************************************)
@@ -67,7 +67,7 @@ Proof.
 apply: boolp.funext => x.
 rewrite -compA FCompE FCompE//= reader_map.
 apply: boolp.funext => s //=.
-rewrite !fmapE//=.
+rewrite compE !fmapE//=.
 congr bind.
 by apply: boolp.funext => -[].
 Qed.
@@ -110,7 +110,7 @@ Lemma whilel (f g : A -> elgotS (B + A)) (a : A) :
 Proof.
 rewrite /wB /while /uncurry /curry => Hfg s.
 apply: whilewB => -[a' s'] /=.
-rewrite !fmapE /=.
+rewrite !compE !fmapE /=.
 exact: bindmwB.
 Qed.
 
@@ -118,7 +118,7 @@ Lemma fixpoint (f : A -> elgotS (B + A)) (a : A) :
   while f a ≈ (f a >>= sum_rect (fun=> elgotS B) Ret (while f)).
 Proof.
 move=> s.
-rewrite /while /curry /dist1/= MS_bindE /uncurry/= fixpointwB/= fmapE !bindA.
+rewrite /while /curry /dist1/= MS_bindE /uncurry/= fixpointwB compE/= fmapE !bindA.
 by apply: bindfwB=> -[[b'|a'] s'] /=; rewrite bindretf.
 Qed.
 
@@ -133,15 +133,15 @@ Proof.
 rewrite /bindS /while /curry /uncurry => s //=.
 rewrite naturalitywB /=.
 apply: whilewB => -[] s' a' /=.
-rewrite fmapE fmapE /=MS_bindE !bindA.
+rewrite !compE 2!fmapE /=MS_bindE !bindA.
 apply: bindfwB => sba //=.
 rewrite /dist1 /uncurry bindretf.
 case: sba => [[b''|a''] s''] /=.
-- rewrite elgotS_map -compA FCompE FCompE reader_map/= fmapE fmapE bindA.
+- rewrite elgotS_map -compA !FCompE !compE/= reader_map/= compE fmapE fmapE bindA.
   apply: bindfwB => cs /=.
   rewrite bindretf /= writer_map /=.
   by case: cs.
-- rewrite elgotS_map -compA FCompE FCompE reader_map/= fmapE fmapE bindA.
+- rewrite elgotS_map -compA !FCompE !compE/= reader_map/= compE fmapE fmapE bindA.
   apply: bindfwB => cs/=.
   rewrite bindretf /= writer_map /=.
   by case: cs.
@@ -156,15 +156,15 @@ rewrite /while /curry /wB => s.
 setoid_symmetry.
 apply: wBisim_trans.
   apply whilewB => -[] s' a' /=.
-  by rewrite /uncurry fmapE naturalitywB.
+  by rewrite /uncurry compE fmapE naturalitywB.
 rewrite -codiagonalwB elgotS_map.
 apply: whilewB => -[] a'' s'' //=.
-rewrite //= !fmapE.
+rewrite !compE //= !fmapE.
 have -> : ((reader S \o M) \o writer S) # sum_rect (fun=> (B + A)%type) idfun inr =
           reader S # (M # (writer S # sum_rect (fun=> (B + A)%type) idfun inr)).
   by rewrite -compA FCompE.
-rewrite reader_map /= fmapE !bindA.
-by apply: bindfwB => -[[[bl|al']|al] sl]; rewrite !bindretf /= fmapE !bindretf.
+rewrite compE reader_map compE/= fmapE !bindA.
+by apply: bindfwB => -[[[bl|al']|al] sl]; rewrite !bindretf/= !compE/= fmapE !bindretf.
 Qed.
 
 Lemma uniform {A B C} (f : A -> elgotS (B + A)) (g : C -> elgotS (B + C))
@@ -180,9 +180,9 @@ rewrite /while /curry /=.
 set h' := fun cs : C * S => let (c, s) := cs in (h c, s).
 have -> : (h c, s) = h' (c, s) by [].
 apply: (uniformwB _ _ _ _ _ h') => -[c' s'].
-rewrite {}/h' /= fmapE (H c') fmapE /= !bindA.
+rewrite {}/h' /= compE/= fmapE (H c') compE fmapE /= !bindA.
 by apply: bindfwB => -[[?|?] ?];
-  rewrite /=bindretf fmapE !bindretf/= fmapE bindretf.
+  rewrite /=bindretf !compE/= fmapE !bindretf/= !compE/= fmapE bindretf.
 Qed.
 
 HB.instance Definition _ := @hasWBisim.Build elgotS wB
@@ -252,7 +252,7 @@ Qed.
 Lemma fixpoint {A B} (f : A -> elgotX (B + A)) (a : A) :
   while f a ≈ f a >>= sum_rect (fun => elgotX B ) Ret (while f).
 Proof.
-rewrite /while /elgotXA fixpointwB /= fmapE /= bindA.
+rewrite /while /elgotXA fixpointwB /= !compE/= fmapE /= bindA.
 apply (bindfwB _ _ _ _ (f a)) => uba.
 by case: uba => [u|[b'|a']] /=; rewrite bindretf.
 Qed.
@@ -265,13 +265,13 @@ Lemma naturality {A B C} (f : A -> elgotX (B + A)) (g : B -> elgotX C) (a : A) :
 Proof.
 rewrite /while /elgotXA bindXE naturalitywB.
 apply: whilewB => a' /=.
-rewrite fmapE fmapE !bindA.
+rewrite !compE/= 2!fmapE !bindA.
 apply: (bindfwB _ _ _ _ (f a')).
 move=> [u|[b''|a'']] /=.
-- by rewrite !bindretf /= fmapE bindretf.
-- rewrite !bindretf /= fmapE /= fmapE bindA.
+- by rewrite !bindretf/= compE/= fmapE bindretf.
+- rewrite !bindretf/= !compE/= fmapE /= fmapE bindA.
   by apply: bindfwB => -[u|c]; rewrite bindretf.
-- by rewrite bindretf /= !fmapE !bindretf.
+- by rewrite bindretf/= !compE/= !fmapE !bindretf.
 Qed.
 
 Lemma codiagonal {A B} (f : A -> elgotX ((B + A) + A)) (a : A) :
@@ -285,12 +285,12 @@ setoid_symmetry.
 apply: wBisim_trans.
   apply whilewB => a' /=.
   set m := {1}(hierarchy.while _ ).
-  by rewrite (fmapE g (m a')) naturalitywB.
+  by rewrite !compE/= (fmapE g (m a')) naturalitywB.
 rewrite -codiagonalwB.
 apply whilewB => a' /=.
-rewrite !fmapE !bindA.
+rewrite !compE/= !fmapE !bindA.
 apply: bindfwB.
-by move=> [u|[[b|a1]|a2]] /=; rewrite !bindretf /= fmapE bindretf /= bindretf.
+by move=> [u|[[b|a1]|a2]] /=; rewrite !bindretf/= !compE/= fmapE bindretf /= bindretf.
 Qed.
 
 Lemma whilel {A B} (f g : A -> elgotX (B + A)) (a : A) :
@@ -299,7 +299,7 @@ Proof.
 move=> Hfg.
 rewrite /while /elgotXA.
 apply: whilewB => a' /=.
-rewrite !fmapE.
+rewrite !compE !fmapE.
 apply: bindmwB.
 exact: Hfg.
 Qed.
@@ -313,9 +313,9 @@ Proof.
 move=> H c.
 rewrite /while.
 apply: (uniformwB _ _ _ (elgotXA \o f)) => c' /=.
-rewrite /elgotXA/= !fmapE (H c') !bindA.
+rewrite /elgotXA/= !compE !fmapE (H c') !bindA.
 apply: bindfwB.
-by move=> [x|[b''|c'']]; rewrite /= !bindretf /= fmapE !bindretf // fmapE bindretf.
+by move=> [x|[b''|c'']]; rewrite /= !bindretf /= !compE fmapE !bindretf // fmapE bindretf.
 Qed.
 
 HB.instance Definition _ := MonadExcept.on elgotX.

--- a/theories/models/gcm_model.v
+++ b/theories/models/gcm_model.v
@@ -195,7 +195,7 @@ Let affine_idfun' (U : convType R) : affine (@idfun U). Proof. by []. Qed.
 
 Let affine_comp' (a b c : convType R) (f : a -> b) (g : b -> c) :
   affine f -> affine g -> affine (g \o f).
-Proof. by move=> hf hg ? ? ? /=; rewrite hf hg. Qed.
+Proof. by move=> hf hg ? ? ? /=; rewrite compE hf hg. Qed.
 
 HB.instance Definition _ := isCategory.Build (convType R) (fun A : convType R => A)
   _ affine_idfun' affine_comp'.
@@ -302,7 +302,7 @@ Let eps0' : F0 \O U0 ~~> FId := fun a =>
 Let eps0'_natural : naturality _ _ eps0'.
 Proof.
 move=> C D f; rewrite FCompE /= /id_f; apply funext => d /=.
-by rewrite Convn_of_fsdistmap.
+by rewrite compE Convn_of_fsdistmap.
 Qed.
 
 HB.instance Definition _ := isNatural.Build _ _ _ _ _ eps0'_natural.
@@ -316,7 +316,7 @@ Let eta0' : FId ~~> U0 \O F0 := fun T =>
 
 Lemma eta0'_natural : naturality _ _ eta0'.
 Proof.
-by move=> a b h; rewrite funeqE=> x; rewrite FIdf /eta0' /= fsdistmap1.
+by move=> a b h; rewrite funeqE=> x; rewrite FIdf /eta0' compE/= fsdistmap1.
 Qed.
 
 HB.instance Definition _ := isNatural.Build _ _ _ _ _ eta0'_natural.
@@ -331,12 +331,12 @@ Local Open Scope ring_scope.
 
 Lemma triL0 : TriangularLaws.left eta0 eps0.
 Proof.
-by move=> c; apply funext=> x /=; rewrite eps0E eta0E triangular_laws_left0.
+by move=> c; apply funext=> x /=; rewrite eps0E eta0E compE triangular_laws_left0.
 Qed.
 
 Lemma triR0 : TriangularLaws.right eta0 eps0.
 Proof.
-by move=> c; rewrite eps0E eta0E funeqE => a /=; rewrite Convn_of_fsdist1.
+by move=> c; rewrite eps0E eta0E funeqE => a /=; rewrite compE Convn_of_fsdist1.
 Qed.
 
 End eps0_eta0.
@@ -367,9 +367,9 @@ Let comp_is_biglub_affine (a b c : semiCompSemiLattConvType R)
   biglub_affine f -> biglub_affine g -> biglub_affine (g \o f).
 Proof.
 move=> [bf af] [bg ag]; split => x/=.
-  rewrite bf bg/=;congr (biglub _).
+  rewrite compE bf bg/=; congr (biglub _).
   by apply/neset_ext => /=; rewrite image_comp.
-by move=> ? ? /=; rewrite af ag.
+by move=> ? ? /=; rewrite compE af ag.
 Qed.
 
 Let idfun_is_biglub_affine (a : semiCompSemiLattConvType R) :
@@ -577,7 +577,7 @@ Let eps1' : F1 \O U1 ~~> FId := fun L => Hom.Pack (Hom.Class (isHom.Axioms_
 Lemma eps1'_natural : naturality _ _ eps1'.
 Proof.
 move=> K L f /=; rewrite funeqE => X /=.
-rewrite biglub_morph; congr (|_| _).
+rewrite compE biglub_morph; congr (|_| _).
 by rewrite free_semiCompSemiLattConvType_morE.
 Qed.
 
@@ -626,7 +626,7 @@ rewrite eqEsubset eta1E; split=> a.
 Qed.
 
 Lemma triR1 : TriangularLaws.right eta1 eps1.
-Proof. by move=> c; apply funext=> /= x; rewrite eps1E eta1E /= biglub1. Qed.
+Proof. by move=> c; apply funext=> /= x; rewrite eps1E eta1E compE biglub1. Qed.
 
 End eps1_eta1.
 
@@ -738,7 +738,7 @@ rewrite /= /join_ /= /Monad_of_category_monad.join /= !HCompId !HIdComp eps1E.
 rewrite functor_o NEqE functor_id compfid.
 rewrite 2!VCompE_nat HCompId HIdComp.
 set E := epsC _; have->: E = [hom idfun] by apply/hom_ext; rewrite epsCE.
-rewrite functor_id_hom.
+rewrite functor_id_hom/=.
 rewrite !functor_o functor_id !compfid.
 set F1J := F1 # _.
 have-> : F1J = @necset_join.F1join0 _ _ :> (_ -> _).
@@ -772,11 +772,15 @@ Local Open Scope monae_scope.
 
 Lemma JoinE T : (Join : (N \o N) T -> N T) = (Join : (M R \o M R) T -> M R T).
 Proof.
-apply funext => t /=.
+apply: funext => t /=.
 rewrite /join_.
 rewrite [in LHS]/= HCompId HIdComp [X in _ (X t)]/=.
 rewrite /actm [in LHS]/=.
 rewrite epsCE.
+(* NB: the equation here involves `comp` in its type, therefore naive rewriting with
+   `compE` first matches its type part and leads to a dependent-type error.
+   To avoid that, the pattern specifier `in LHS` is necessary. *)
+rewrite ![in LHS]compE.
 rewrite eps0_correct.
 rewrite /fsdistjoin /fsdistmap /= fsdistbindA /=.
 congr fsdistbind.

--- a/theories/models/monad_model.v
+++ b/theories/models/monad_model.v
@@ -324,7 +324,7 @@ Let left_neutral : BindLaws.left_neutral bind ret.
 Proof. by move=> A B a f; apply boolp.funext. Qed.
 Let right_neutral : BindLaws.right_neutral bind ret.
 Proof.
-by move=> A f; apply boolp.funext => s; rewrite /bind /=; case: (f s).
+by move=> A f; apply boolp.funext => s; rewrite /bind compE/=; case: (f s).
 Qed.
 Let associative : BindLaws.associative bind.
 Proof.
@@ -457,7 +457,7 @@ Let naturality_output :
 Proof.
 move=> A B h.
 apply boolp.funext => -[w [x w']].
-by rewrite /output /= catA.
+by rewrite /output !compE/= catA.
 Qed.
 
 HB.instance Definition _ := isNatural.Build
@@ -1527,17 +1527,17 @@ Definition aput i s : M unit := fun a => (tt, insert i s a).
 Let aputput i s s' : aput i s >> aput i s' = aput i s'.
 Proof.
 rewrite state_bindE; apply boolp.funext => a/=.
-by rewrite /aput insert_insert.
+by rewrite /aput compE/= insert_insert.
 Qed.
 Let aputget i s A (k : S -> M A) : aput i s >> aget i >>= k = aput i s >> k s.
 Proof.
 rewrite state_bindE; apply boolp.funext => a/=.
-by rewrite /aput insert_same.
+by rewrite /aput compE/= insert_same.
 Qed.
 Let agetput i : aget i >>= aput i = skip.
 Proof.
 rewrite state_bindE; apply boolp.funext => a/=.
-by rewrite /aput insert_same2.
+by rewrite /aput compE/= insert_same2.
 Qed.
 Let agetget i A (k : S -> S -> M A) :
   aget i >>= (fun s => aget i >>= k s) = aget i >>= fun s => k s s.
@@ -1550,13 +1550,13 @@ Let aputC i j u v : (i != j) \/ (u = v) ->
   aput i u >> aput j v = aput j v >> aput i u.
 Proof.
 by move=> [ij|->{u}]; rewrite !state_bindE /aput; apply/boolp.funext => a/=;
-  [rewrite insertC|rewrite insertC2].
+  [rewrite compE/= insertC|rewrite compE/= insertC2].
 Qed.
 Let aputgetC i j u A (k : S -> M A) : i != j ->
   aput i u >> aget j >>= k = aget j >>= (fun v => aput i u >> k v).
 Proof.
 move=> ij; rewrite /aput !state_bindE; apply boolp.funext => a/=.
-by rewrite state_bindE/= {1}/insert (negbTE ij).
+by rewrite !compE/= state_bindE/= {1}/insert (negbTE ij).
 Qed.
 HB.instance Definition _ := Monad.on M.
 HB.instance Definition _ := isMonadArray.Build
@@ -2007,7 +2007,7 @@ Let runStateTbind : forall (A B : UU0) (m : M A) (f : A -> M B) (s : S),
 Proof.
 move=> A M m f s /=.
 rewrite /= /runStateT bindE /= /join_of_bind /bindS /=.
-rewrite MS_mapE /actm /=.
+rewrite MS_mapE /actm !compE/=.
 by case: (m s).
 Qed.
 Let runStateTget : forall s : S, runStateT get s = Ret (s, s) :> N _.

--- a/theories/models/typed_store_model.v
+++ b/theories/models/typed_store_model.v
@@ -516,10 +516,9 @@ Let crunnewgetC (A : UU0) T1 T2 (m : M A) (r : A -> loc T1)
   crun (m >>= fun x => cget (r x)) ->
   crun (m >>= fun x => cnew (s x) >> cget (r x)).
 Proof.
-rewrite /crun /= !bindE /= /bindS !MS_mapE /= !fmapE /= !bindA /=.
+rewrite /crun /= !bindE /= /bindS !MS_mapE compE/= !fmapE /= !bindA /=.
 case Hm: (m _) => [|[a b]] //.
-rewrite !bindE /= !bindE /= /bindS MS_mapE /= fmapE /= bindA.
-rewrite !bindE /= !bindE /= /cget.
+rewrite !bindE /= !bindE /= bind_cnew /cget.
 case Hnth: nth_error => [[]|] //.
 rewrite (nth_error_rcons_some _ Hnth).
 by case Hcoe: coerce.
@@ -529,7 +528,7 @@ Let crungetput (A : UU0) T (m : M A) (r : A -> loc T) (s : A -> coq_type T) :
   crun (m >>= fun x => cget (r x)) ->
   crun (m >>= fun x => cput (r x) (s x)).
 Proof.
-rewrite /crun /= !bindE /= /bindS !MS_mapE /= !fmapE /= !bindA /=.
+rewrite /crun /= !bindE /= /bindS !MS_mapE compE/= !fmapE /= !bindA /=.
 case Hm: (m _) => [|[a [b]]] //=.
 rewrite !bindE /= !bindE /= /cget /cput /=.
 case Hnth: nth_error => [[T' v]|] //.
@@ -541,7 +540,7 @@ Qed.
 
 Let crunmskip (A : UU0) (m : M A) : crun (m >> skip) = crun m :> bool.
 Proof.
-rewrite /crun /= !bindE /= /bindS !MS_mapE /= !fmapE /= !bindA.
+rewrite /crun /= !bindE /= /bindS !MS_mapE compE/= !fmapE /= !bindA.
 by case Hm: (m _) => [|[]].
 Qed.
 

--- a/theories/models/typed_store_transformer.v
+++ b/theories/models/typed_store_transformer.v
@@ -306,10 +306,11 @@ have [u r1u|T1' v1 Hr1 T1v1|Hr1] := ntherrorP e r1.
     have [?|T1'T1] := eqVneq T1' T1.
     * subst T1'; rewrite coerce_Some.
       rewrite [in LHS]bindE/= !MX_mapE !fmapE bindretf /= /bindX !bindretf (Some_cputE _ r2v) [in RHS]bindE/=.
+      rewrite /cput.
       have [Hr|Hr] := eqVneq (loc_id r1) (loc_id r2).
         move: r2v; rewrite -Hr Hr1 => -[?] _; subst T2.
         by rewrite !MX_mapE !fmapE bindretf /= /bindX !bindretf /= /cget nth_error_set_nth coerce_Some bindretf /=.
-      by rewrite MX_mapE fmapE bindretf /= /bindX bindretf /=/cget (nth_error_set_nth_other _ _ Hr Hr1) coerce_Some bindretf /=.
+      by rewrite MX_mapE fmapE bindretf compE/= /bindX bindretf/= /cget (nth_error_set_nth_other _ _ Hr Hr1) r2v !coerce_Some bindretf /=.
     * rewrite coerce_None//= bindfailf (Some_cputE _ r2v) [in RHS]bindE/=.
       have [r12|r12] := eqVneq (loc_id r1) (loc_id r2).
         move: r2v; rewrite -r12 Hr1 => -[?] _; subst T1'.
@@ -541,7 +542,7 @@ Qed.
 
 Local Definition crunmskip (A : UU0) (m : M A) : crun (m >> skip) = crun m :> bool.
 Proof.
-rewrite /crun /= !bindE /= /bindS !MS_mapE /= !fmapE /= !bindA.
+rewrite /crun /= !bindE /= /bindS !MS_mapE /= !compE !fmapE /= !bindA.
 by case Hm: (m _) => [|[]].
 Qed.
 


### PR DESCRIPTION
`ssrfun.comp` (notation `_ \o _`), as provided by `ssrfun`, has its arguments flag set so that
an expression `(f \o g) x` is automatically reduced to `f (g x)`.

This PR sets `simpl never` flag to `ssrfun.comp`, thus necessitating uses of
a simplification lemma `compE`.

This change was suggested in the discussion at PR #188.