### PR TITLE
reexport boolp.funext as preamble.funext

### DIFF
--- a/theories/applications/example_iquicksort.v
+++ b/theories/applications/example_iquicksort.v
@@ -474,7 +474,7 @@ Lemma iqsort'_Fix (ni : nat * nat)
   (forall (n'j : nat * nat) (p : (n'j.2 < ni.2)%coq_nat), f n'j p = g n'j p) ->
   iqsort' f = iqsort' g.
 Proof.
-by move=> ?; congr iqsort'; apply funext_dep => ?; apply boolp.funext.
+by move=> ?; congr iqsort'; apply funext_dep => ?; apply funext.
 Qed.
 
 Lemma iqsort_nil i : iqsort (i, 0) = Ret tt.

--- a/theories/applications/example_transformer.v
+++ b/theories/applications/example_transformer.v
@@ -83,7 +83,7 @@ Qed.
 Lemma bindmret (A : UU0) (m : failPState A) :
 bind m ret = m.
 Proof.
-apply: boolp.funext => s.
+apply: funext => s.
 unfold bind.
 destruct (m s) as [[|]]; reflexivity.
 Qed.
@@ -93,7 +93,7 @@ Lemma bindA
   (f : A -> failPState B) (g : B -> failPState C) :
 bind (bind m f) g = bind m (fun x => bind (f x) g).
 Proof.
-apply: boolp.funext => s.
+apply: funext => s.
 unfold bind.
 destruct (m s) as [[|]]; reflexivity.
 Qed.
@@ -187,7 +187,7 @@ Lemma bindLmfail (M := [the monad of option_monad]) S T U (m : stateT S M U)
   m >> Lift [the monadT of stateT S] M T FAIL =
   Lift [the monadT of stateT S] M T FAIL.
 Proof.
-rewrite /= /liftS; apply: boolp.funext => s.
+rewrite /= /liftS; apply: funext => s.
 rewrite except_bindE.
 rewrite {1}bindE /= MS_mapE {1}/bindS compE/=.
 by case (m s) => // -[].

--- a/theories/core/hierarchy.v
+++ b/theories/core/hierarchy.v
@@ -214,7 +214,7 @@ Proof. by rewrite /FunctorLaws.id => A; rewrite /comp_actm 2!functor_id. Qed.
 Let comp_comp : FunctorLaws.comp comp_actm.
 Proof.
 rewrite /FunctorLaws.comp => A B C g' h; rewrite /comp_actm.
-by apply boolp.funext => m; rewrite [in RHS]compE 2!functor_o.
+by apply funext => m; rewrite [in RHS]compE 2!functor_o.
 Qed.
 
 HB.instance Definition _ := isFunctor.Build (F \o G) comp_id comp_comp.
@@ -446,7 +446,7 @@ HB.end.
 
 Lemma eq_bind (M : monad) (A B : UU0) (m : M A) (f1 f2 : A -> M B) :
   f1 =1 f2 -> m >>= f1 = m >>= f2.
-Proof. by move=> f12; congr bind; apply boolp.funext. Qed.
+Proof. by move=> f12; congr bind; apply funext. Qed.
 
 Section monad_lemmas.
 Variable M : monad.
@@ -502,17 +502,17 @@ Let actm (a b : UU0) (f : a -> b) m := bind m (@ret _ \o f).
 Let actm_id : FunctorLaws.id actm.
 Proof.
 move=> a.
-rewrite /actm; apply: boolp.funext => m /=.
+rewrite /actm; apply: funext => m /=.
 by rewrite bindmret.
 Qed.
 
 Let actm_comp : FunctorLaws.comp actm.
 Proof.
 move=> a b c g h.
-rewrite /actm; apply: boolp.funext => m /=.
+rewrite /actm; apply: funext => m /=.
 rewrite compE bindA.
 congr bind.
-apply: boolp.funext => u /=.
+apply: funext => u /=.
 by rewrite bindretf.
 Qed.
 
@@ -523,7 +523,7 @@ Local Notation FF := [the functor of F \o F].
 Let ret_naturality : naturality idfun F ret.
 Proof.
 move=> a b h.
-rewrite FIdE /hierarchy.actm /= /actm; apply: boolp.funext => m /=.
+rewrite FIdE /hierarchy.actm /= /actm; apply: funext => m /=.
 by rewrite compE bindretf.
 Qed.
 
@@ -539,11 +539,11 @@ Proof. by rewrite /actm bindA. Qed.
 Let join'_naturality : naturality FF F join'.
 Proof.
 move=> a b h.
-rewrite /join' /=; apply: boolp.funext => mm /=.
+rewrite /join' /=; apply: funext => mm /=.
 rewrite /hierarchy.actm /= /isFunctor.actm /=.
 rewrite !compE actm_bind bindA.
 congr bind.
-apply: boolp.funext => m /=.
+apply: funext => m /=.
 by rewrite bindretf /=.
 Qed.
 
@@ -554,7 +554,7 @@ Let bind_map (A B C : UU0) (f : A -> B) (m : M A) (g : B -> M C) :
   bind ((F # f) m) g = bind m (g \o f).
 Proof.
 rewrite bindA; congr bind.
-by apply: boolp.funext => ?; rewrite bindretf.
+by apply: funext => ?; rewrite bindretf.
 Qed.
 
 Let bindE (a b : UU0) (f : a -> M b) (m : M a) :
@@ -566,28 +566,28 @@ Qed.
 
 Let joinretM : JoinLaws.left_unit ret join.
 Proof.
-move=> a; apply: boolp.funext => m.
+move=> a; apply: funext => m.
 by rewrite /join /= /join' /= compE bindretf.
 Qed.
 
 Let joinMret : JoinLaws.right_unit ret join.
 Proof.
-move=> a; apply: boolp.funext => m.
+move=> a; apply: funext => m.
 rewrite /join /= /join'.
 rewrite /hierarchy.actm /= /actm /=.
 rewrite compE bindA /=.
-rewrite [X in bind m X](_ : _ = fun x => ret x) ?bindmret //=; apply: boolp.funext => ?.
+rewrite [X in bind m X](_ : _ = fun x => ret x) ?bindmret //=; apply: funext => ?.
 by rewrite bindretf.
 Qed.
 
 Let joinA : JoinLaws.associativity join.
 Proof.
-move => a; apply: boolp.funext => m.
+move => a; apply: funext => m.
 rewrite /join /= /join'.
 rewrite /hierarchy.actm /= /actm.
 rewrite compE [in RHS]compE !bindA.
 congr bind.
-apply: boolp.funext => u /=.
+apply: funext => u /=.
 by rewrite bindretf.
 Qed.
 
@@ -616,7 +616,7 @@ Definition skip M := @ret M _ tt.
 Arguments skip {M} : simpl never.
 
 Ltac bind_ext :=
-  let congr_ext m := ltac:(congr (bind m); apply boolp.funext) in
+  let congr_ext m := ltac:(congr (bind m); apply funext) in
   match goal with
     | |- @bind _ _ _ ?m ?f1 = @bind _ _ _ ?m ?f2 =>
       congr_ext m
@@ -643,7 +643,7 @@ Tactic Notation "With" tactic(tac) "Open" ssrpatternarg(pat) :=
   evar (g : typ);
   rewrite (_ : f = g);
   [rewrite {}/f {}/g|
-   apply boolp.funext => x; rewrite {}/g {}/f; tac]; last first.
+   apply funext => x; rewrite {}/g {}/f; tac]; last first.
 
 Tactic Notation "Open" ssrpatternarg(pat) :=
   With (idtac) Open pat.
@@ -784,7 +784,7 @@ Definition bassert {A : UU0} (p : pred A) (m : M A) : M A := m >>= assert p.
 Lemma commutativity_of_assertions A q :
   Join \o (M # (bassert q)) = bassert q \o Join :> (_ -> M A).
 Proof.
-by apply boolp.funext => x; rewrite !compE join_fmap /bassert joinE bindA.
+by apply funext => x; rewrite !compE join_fmap /bassert joinE bindA.
 Qed.
 
 (* guards commute with anything *)

--- a/theories/core/monad_transformer.v
+++ b/theories/core/monad_transformer.v
@@ -76,7 +76,7 @@ HB.builders Context (M N : monad) (e : M ~~> N) of isMonadM_ret_bind M N e.
 
 Lemma naturality_monadM : naturality M N e.
 Proof.
-move=> A B h; apply boolp.funext => m /=.
+move=> A B h; apply funext => m /=.
 by rewrite !compE !fmapE monadMbind (compA (e B)) monadMret.
 Qed.
 
@@ -102,18 +102,18 @@ Definition bindS (A B : UU0) (m : MS A) f : MS B := fun s => m s >>= uncurry f.
 
 Let bindSretf : BindLaws.left_neutral bindS retS.
 Proof.
-by move=> A B a f; rewrite /bindS; apply boolp.funext => s; rewrite bindretf.
+by move=> A B a f; rewrite /bindS; apply funext => s; rewrite bindretf.
 Qed.
 
 Let bindSmret : BindLaws.right_neutral bindS retS.
 Proof.
-move=> A m; rewrite /bindS; apply boolp.funext => s.
+move=> A m; rewrite /bindS; apply funext => s.
 by rewrite -[in RHS](bindmret (m s)); bind_ext; case.
 Qed.
 
 Let bindSA : BindLaws.associative bindS.
 Proof.
-move=> A B C m f g; rewrite /bindS; apply boolp.funext => s.
+move=> A B C m f g; rewrite /bindS; apply funext => s.
 by rewrite bindA; bind_ext; case.
 Qed.
 
@@ -123,10 +123,10 @@ HB.instance Definition _ :=
 Lemma MS_mapE (A B : UU0) (f : A -> B) (m : MS A) :
   ([the functor of MS] # f) m = (M # (fun x => (f x.1, x.2))) \o m.
 Proof.
-apply boolp.funext=> s.
+apply funext=> s.
 rewrite {1}/actm /= /bindS compE/= fmapE.
 congr bind.
-by apply: boolp.funext; case.
+by apply: funext; case.
 Qed.
 
 Definition liftS (A : UU0) (m : M A) : MS A :=
@@ -134,13 +134,13 @@ Definition liftS (A : UU0) (m : M A) : MS A :=
 
 Let retliftS : MonadMLaws.ret liftS.
 Proof.
-move=> A; rewrite /liftS; apply: boolp.funext => a /=; apply: boolp.funext => s /=.
+move=> A; rewrite /liftS; apply: funext => a /=; apply: funext => s /=.
 by rewrite compE bindretf.
 Qed.
 
 Let bindliftS : MonadMLaws.bind liftS.
 Proof.
-move=> A B m f; rewrite {1}/liftS; apply: boolp.funext => s.
+move=> A B m f; rewrite {1}/liftS; apply: funext => s.
 rewrite [in LHS]bindA.
 transitivity (liftS m s >>= uncurry (@liftS B \o f)) => //.
 rewrite [in RHS]bindA.
@@ -175,27 +175,27 @@ Let Get : MS S M S := fun s => Ret (s, s).
 Let bindputput s s' : Put s >> Put s' = Put s'.
 Proof.
 rewrite /Ret.
-rewrite bindE /= /bindS; apply: boolp.funext => s0.
+rewrite bindE /= /bindS; apply: funext => s0.
 by rewrite MS_mapE bind_fmap bindretf.
 Qed.
 
 Let bindputget s : Put s >> Get = Put s >> Ret s.
 Proof.
 rewrite !bindE !MS_mapE /= /bindS.
-apply: boolp.funext => s'.
+apply: funext => s'.
 by rewrite !bind_fmap !bindretf.
 Qed.
 
 Let bindgetput : Get >>= Put = skip.
 Proof.
 rewrite bindE MS_mapE /= /bindS.
-by apply: boolp.funext => s; rewrite bind_fmap bindretf.
+by apply: funext => s; rewrite bind_fmap bindretf.
 Qed.
 
 Let bindgetget (A : UU0) (k : S -> S -> stateT S M A) :
   Get >>= (fun s => Get >>= k s) = Get >>= (fun s => k s s).
 Proof.
-apply: boolp.funext => s.
+apply: funext => s.
 rewrite /Get/=.
 rewrite !bindE !MS_mapE /= /bindS /= /retS/=.
 rewrite !bind_fmap !bindretf/=.
@@ -241,17 +241,17 @@ HB.instance Definition _ :=
 Lemma MX_mapE (A B : UU0) (f : A -> B) :
   [the functor of MX] # f = M # (fun x => match x with inl y => inl y | inr y => inr (f y) end).
 Proof.
-apply: boolp.funext => m.
+apply: funext => m.
 rewrite {1}/actm /= /bindX /= [in RHS]fmapE.
 congr (_ _).
-by apply: boolp.funext; case.
+by apply: funext; case.
 Qed.
 
 Definition liftX X (m : M X) : MX X := m >>= (@ret [the monad of MX] _).
 
 Let retliftX : MonadMLaws.ret liftX.
 Proof.
-by move=> A; apply: boolp.funext => a; rewrite /liftX compE/= bindretf.
+by move=> A; apply: funext => a; rewrite /liftX compE/= bindretf.
 Qed.
 
 Let bindliftX : MonadMLaws.bind liftX.
@@ -343,18 +343,18 @@ Definition bindEnv A B (m : MEnv A) f : MEnv B :=
 
 Let bindEnvretf : BindLaws.left_neutral bindEnv retEnv.
 Proof.
-by move=> A B a f; rewrite /bindEnv; apply: boolp.funext => r; rewrite bindretf.
+by move=> A B a f; rewrite /bindEnv; apply: funext => r; rewrite bindretf.
 Qed.
 
 Let bindEnvmret : BindLaws.right_neutral bindEnv retEnv.
 Proof.
-move=> A m; rewrite /bindEnv; apply: boolp.funext => r.
+move=> A m; rewrite /bindEnv; apply: funext => r.
 rewrite -[in RHS](bindmret (m r)); by bind_ext; case.
 Qed.
 
 Let bindEnvA : BindLaws.associative bindEnv.
 Proof.
-move=> A B C m f g; rewrite /bindEnv; apply: boolp.funext => r.
+move=> A B C m f g; rewrite /bindEnv; apply: funext => r.
 by rewrite bindA; bind_ext; case.
 Qed.
 
@@ -363,7 +363,7 @@ HB.instance Definition _ :=
 
 Lemma MEnv_mapE (A B : UU0) (f : A -> B) (m : MEnv A) :
   (MEnv # f) m = (M # f) \o m.
-Proof. by apply: boolp.funext => r; rewrite compE/= fmapE. Qed.
+Proof. by apply: funext => r; rewrite compE/= fmapE. Qed.
 
 Definition liftEnv A (m : M A) : MEnv A := fun r => m.
 
@@ -398,7 +398,7 @@ Let bindOretf : BindLaws.left_neutral bindO retO.
 Proof.
 move=> A B a f; rewrite /bindO /= bindretf /=.
 rewrite (_ : (fun o' : B * seq R => _) = (fun o => Ret o)) ?bindmret //.
-by apply: boolp.funext => -[].
+by apply: funext => -[].
 Qed.
 
 Let bindOmret : BindLaws.right_neutral bindO retO.
@@ -424,7 +424,7 @@ Lemma MO_mapE (A B : UU0) (f : A -> B) (m : MO A) :
 Proof.
 rewrite [in LHS]/actm /= /bindO /= [in RHS]fmapE.
 congr (_ _).
-apply: boolp.funext => -[] ? ?.
+apply: funext => -[] ? ?.
 by  rewrite bindretf cats0.
 Qed.
 
@@ -432,7 +432,7 @@ Definition liftO A (m : M A) : MO A := m >>= (fun x => Ret (x, [::])).
 
 Let retliftO : MonadMLaws.ret liftO.
 Proof.
-move=> a; rewrite /liftO /= /retO; apply: boolp.funext => o /=.
+move=> a; rewrite /liftO /= /retO; apply: funext => o /=.
 by rewrite compE bindretf.
 Qed.
 
@@ -486,13 +486,13 @@ Definition liftC A (x : M A) : MC A := fun k => x >>= k.
 
 Let retliftC : MonadMLaws.ret liftC.
 Proof.
-move => A; rewrite /liftC; apply: boolp.funext => a /=.
-by apply: boolp.funext => s; rewrite compE bindretf.
+move => A; rewrite /liftC; apply: funext => a /=.
+by apply: funext => s; rewrite compE bindretf.
 Qed.
 
 Let bindliftC : MonadMLaws.bind liftC.
 Proof.
-move => A B m f; rewrite /liftC; apply: boolp.funext => cont.
+move => A B m f; rewrite /liftC; apply: funext => cont.
 by rewrite 3!bindA.
 Qed.
 
@@ -610,7 +610,7 @@ End continuation_monad_transformer_example.
 Lemma bindLfailf (M : failMonad) S :
   BindLaws.left_zero (@bind (stateT S M)) (Lift _ _ ^~ fail).
 Proof.
-move=> A B g /=; rewrite /liftS; apply: boolp.funext => s; rewrite bindfailf.
+move=> A B g /=; rewrite /liftS; apply: funext => s; rewrite bindfailf.
 set x := (X in X >>= _ = _).
 by rewrite (_ : x = fail) ?bindfailf// /x bindfailf.
 Qed.
@@ -618,10 +618,10 @@ Qed.
 Lemma bindmLfail (M : failR0Monad) S :
   BindLaws.right_zero (@bind (stateT S M)) (Lift _ _ ^~ fail).
 Proof.
-move=> A B m /=; rewrite /liftS/=; apply/boolp.funext => s; rewrite bindfailf.
+move=> A B m /=; rewrite /liftS/=; apply/funext => s; rewrite bindfailf.
 set x := (X in _ >>= X = _).
 rewrite (_ : x = fun=> fail) ?bindmfail//.
-by apply/boolp.funext=> -[b s']; rewrite /x/= bindfailf.
+by apply/funext=> -[b s']; rewrite /x/= bindfailf.
 Qed.
 
 Section lifting.
@@ -667,7 +667,7 @@ rewrite -[in RHS](natural n).
 transitivity (Join ((M # (Join \o (M # g))) (n (M A) t))); last first.
   rewrite -(compE _ (n (M A)) t).
   congr (Join ((M # _ \o _ ) t)).
-  apply: boolp.funext => ma.
+  apply: funext => ma.
   by rewrite bindE.
 rewrite -[in X in Join X = _]compE.
 rewrite compE natural.
@@ -721,7 +721,7 @@ Variables (E : functor) (M : monad).
 Lemma psiK (op : E ~> M) : phi (psi op) = op.
 Proof.
 apply/nattrans_ext => A.
-rewrite phiE /= psiE; apply: boolp.funext => m /=.
+rewrite phiE /= psiE; apply: funext => m /=.
 rewrite !compE.
 rewrite -(compE (op _)) -(natural op) -(compE Join).
 by rewrite compA joinMret.
@@ -731,7 +731,7 @@ Lemma phiK (op : E.-aoperation M) : psi (phi op) = op.
 Proof.
 apply/aoperation_ext => A.
 rewrite /=.
-rewrite psiE phiE; apply boolp.funext => m /=.
+rewrite psiE phiE; apply funext => m /=.
 rewrite !compE.
 rewrite -(compE (op _)) joinE.
 rewrite (algebraic op).
@@ -739,7 +739,7 @@ rewrite -(compE (E # _)) -functor_o.
 rewrite -(compE (op _)).
 set x := _^~ id.
 rewrite (_ : x = Join); last first.
-  apply: boolp.funext => mma.
+  apply: funext => mma.
   by rewrite /x bindE functor_id (*TODO: lemma*).
 by rewrite joinretM functor_id compfid.
 Qed.
@@ -760,7 +760,7 @@ Proof. by rewrite /alifting/= /vcomp; unlock. Qed.
 Theorem uniform_algebraic_lifting : lifting op e alifting.
 Proof.
 move=> X.
-apply: boolp.funext => Y.
+apply: funext => Y.
 rewrite /alifting.
 rewrite [in RHS]/=.
 rewrite psiE.
@@ -850,7 +850,7 @@ HB.instance Definition _ := isFunctorial.Build (exceptT X) hmapX_NId hmapX_v.
 Let monadMret_hmapX (F G : monad) (e : monadM F G) :
   MonadMLaws.ret (hmapX' e).
 Proof.
-move=> A; apply: boolp.funext => /= a.
+move=> A; apply: funext => /= a.
 by rewrite /hmapX' /retX !compE/= -(compE (e _)) monadMret.
 Qed.
 
@@ -861,7 +861,7 @@ move=> A B m f; rewrite /hmapX' /=.
 rewrite !bindE /= !MX_mapE /bindX /= !bind_fmap.
 rewrite !monadMbind /=.
 congr (bind (e (X + A)%type m) _).
-apply boolp.funext => -[x/=|//].
+apply funext => -[x/=|//].
 by rewrite !compE/= -(compE (e _)) monadMret.
 Qed.
 
@@ -874,7 +874,7 @@ move=> h M N t; apply/nattrans_ext => A/=; rewrite !vcompE/=.
 rewrite /hmapX' /=.
 rewrite /liftX /=.
 rewrite /retX /=.
-apply: boolp.funext => ma /=.
+apply: funext => ma /=.
 rewrite (_ : (fun x : A => Ret (inr x)) = Ret \o inr) //.
 rewrite compE -bind_fmap.
 rewrite bindmret.
@@ -903,9 +903,9 @@ move=> A B h.
 rewrite /hmapS /=.
 have H : forall G, [the monad of stateT S G] # h = [the functor of MS S G] # h by [].
 rewrite !H {H}.
-apply: boolp.funext => m /=.
+apply: funext => m /=.
 rewrite !compE !MS_mapE.
-apply: boolp.funext => s /=.
+apply: funext => s /=.
 by rewrite [in LHS]compE -(compE  _ (tau (A * S)%type)) natural.
 Qed.
 
@@ -927,8 +927,8 @@ HB.instance Definition _ := isFunctorial.Build (stateT S) hmapS_NId hmapS_v.
 Let monadMret_hmapS (F G : monad) (e : monadM F G) :
   MonadMLaws.ret (hmapS e).
 Proof.
-move=> A; apply boolp.funext => /= a.
-rewrite /hmapS /= /retS /=; apply: boolp.funext => s.
+move=> A; apply funext => /= a.
+rewrite /hmapS /= /retS /=; apply: funext => s.
 by rewrite compE [in LHS]curryE monadMret.
 Qed.
 
@@ -936,7 +936,7 @@ Let monadMbind_hmapS (F G : monad) (e : monadM F G) :
   MonadMLaws.bind (hmapS e).
 Proof.
 move=> A B m f.
-rewrite /hmapS /=; apply: boolp.funext => s.
+rewrite /hmapS /=; apply: funext => s.
 rewrite /= 2!bindE /= !MS_mapE /bindS /= 2!bind_fmap.
 by rewrite monadMbind.
 Qed.
@@ -949,8 +949,8 @@ Proof.
 move=> h M N t; apply/nattrans_ext => A /=; rewrite !vcompE/=.
 rewrite /hmapS /=.
 rewrite /liftS /=.
-apply: boolp.funext => ma /=.
-apply: boolp.funext => s /=.
+apply: funext => ma /=.
+apply: funext => s /=.
 rewrite !compE ![in LHS]bindE ![in LHS]fmapE ![in LHS]bindE.
 rewrite 2!(_ : (fun x : A => Ret (x, s)) = Ret \o (fun x => (x, s))) //.
 rewrite functor_o.
@@ -998,9 +998,9 @@ rewrite /hmapEnv.
 rewrite /=.
 have H : forall G, [the monad of envT E G] # h = [the functor of MEnv E G] # h by [].
 rewrite !H {H}.
-apply: boolp.funext => m /=.
+apply: funext => m /=.
 rewrite !compE !MEnv_mapE.
-apply: boolp.funext => s /=.
+apply: funext => s /=.
 rewrite !compE -(compE  _ (tau A)).
 by rewrite natural.
 Qed.
@@ -1021,8 +1021,8 @@ HB.instance Definition _ := isFunctorial.Build (envT E) hmapEnv_NId hmapEnv_v.
 Let monadMret_hmapEnv (F G : monad) (e : monadM F G) :
   MonadMLaws.ret (hmapEnv e).
 Proof.
-move=> A; apply: boolp.funext => /= a.
-rewrite /hmapEnv /= /retEnv /=; apply: boolp.funext => s.
+move=> A; apply: funext => /= a.
+rewrite /hmapEnv /= /retEnv /=; apply: funext => s.
 by rewrite -[LHS](compE _ Ret) monadMret.
 Qed.
 
@@ -1030,7 +1030,7 @@ Let monadMbind_hmapEnv (F G : monad) (e : monadM F G) :
   MonadMLaws.bind (hmapEnv e).
 Proof.
 move=> A B m f.
-rewrite /hmapEnv /=; apply: boolp.funext => s.
+rewrite /hmapEnv /=; apply: funext => s.
 rewrite /= 2!bindE /= !MEnv_mapE /bindEnv /= 2!bind_fmap.
 by rewrite monadMbind.
 Qed.
@@ -1041,7 +1041,7 @@ Let hmapEnv_lift :
   h M N n \v Lift T M = Lift T N \v n.
 Proof.
 move=> h M N t; apply/nattrans_ext => A /=; rewrite !vcompE/=.
-by rewrite /hmapEnv/= /liftEnv/=; exact: boolp.funext.
+by rewrite /hmapEnv/= /liftEnv/=; exact: funext.
 Qed.
 
 HB.instance Definition _ := isFMT.Build (envT E)
@@ -1063,7 +1063,7 @@ rewrite /hmapO.
 rewrite /=.
 have H : forall G, [the monad of outputT R G] # h = [the functor of MO R G] # h by [].
 rewrite !H {H}.
-apply boolp.funext => m /=; rewrite !compE !MO_mapE.
+apply funext => m /=; rewrite !compE !MO_mapE.
 rewrite -[in LHS](compE  _ (tau _)).
 by rewrite natural.
 Qed.
@@ -1084,7 +1084,7 @@ HB.instance Definition _ := isFunctorial.Build (outputT R) hmapO_NId hmapO_v.
 Let monadMret_hmapO (F G : monad) (e : monadM F G) :
   MonadMLaws.ret (hmapO e).
 Proof.
-move=> A; apply: boolp.funext => /= a; rewrite /hmapO /= /retO /=.
+move=> A; apply: funext => /= a; rewrite /hmapO /= /retO /=.
 by rewrite -[LHS](compE _ Ret) monadMret.
 Qed.
 
@@ -1110,7 +1110,7 @@ Let hmapO_lift :
 Proof.
 move=> h M N t; apply/nattrans_ext => A /=; rewrite !vcompE/=.
 rewrite /hmapO /= /liftO /=.
-apply: boolp.funext => ma /=.
+apply: funext => ma /=.
 rewrite !compE -!fmapE.
 rewrite -(compE _ (t A)).
 by rewrite natural.

--- a/theories/core/preamble.v
+++ b/theories/core/preamble.v
@@ -10,6 +10,8 @@ Definition proof_irr := boolp.Prop_irrelevance.
 Definition eq_rect_eq :=
   @ProofIrrelevance.ProofIrrelevanceTheory.Eq_rect_eq.eq_rect_eq.
 
+Definition funext {T U : Type} [f g : T -> U] := @boolp.funext T U f g.
+
 Definition funext_dep := boolp.functional_extensionality_dep.
 
 Arguments ssrfun.comp {A B C} : simpl never.
@@ -87,7 +89,7 @@ Variable (g : seq T -> R).
 Hypothesis H1 : g nil = r.
 Hypothesis H2 : forall h t, g (h :: t) = f h (g t).
 Lemma foldr_universal : g = foldr f r.
-Proof. by apply boolp.funext; elim => // h t ih /=; rewrite H2 ih. Qed.
+Proof. by apply funext; elim => // h t ih /=; rewrite H2 ih. Qed.
 Lemma foldr_universal_ext x : g x = foldr f r x.
 Proof. by rewrite -(foldr_universal). Qed.
 End universal.
@@ -97,7 +99,7 @@ Variables (U : Type) (h : U -> R) (w : U) (g : T -> U -> U).
 Hypothesis H1 : h w = r.
 Hypothesis H2 : forall x y, h (g x y) = f x (h y).
 Lemma foldr_fusion : h \o foldr g w = foldr f r.
-Proof. by apply boolp.funext; elim => // a b /= <-; rewrite compE H2. Qed.
+Proof. by apply funext; elim => // a b /= <-; rewrite compE H2. Qed.
 Lemma foldr_fusion_ext x : (h \o foldr g w) x = foldr f r x.
 Proof. by rewrite -foldr_fusion. Qed.
 End fusion_law.
@@ -106,7 +108,7 @@ End fold.
 
 Lemma foldl_revE (T R : Type) (f : R -> T -> R) (z : R) :
   foldl f z \o rev = foldr (fun x : T => f^~ x) z.
-Proof. by apply boolp.funext => s; rewrite -foldl_rev. Qed.
+Proof. by apply funext => s; rewrite -foldl_rev. Qed.
 
 Section curry.
 Variables A B C : Type.
@@ -119,13 +121,13 @@ Lemma curryE D a b (g : A * B -> C) (h : _ -> D) :
 Proof. by []. Qed.
 
 Lemma curryK : cancel (@curry A B C) uncurry.
-Proof. by move=> f; apply boolp.funext => -[]. Qed.
+Proof. by move=> f; apply funext => -[]. Qed.
 
 Lemma uncurryK f : cancel (@uncurry A B C) curry.
 Proof. by []. Qed.
 
 Lemma eq_uncurry f g : f =1 g -> uncurry f = uncurry g.
-Proof. by move=> fg; apply/boolp.funext => -[a b]/=; rewrite fg. Qed.
+Proof. by move=> fg; apply/funext => -[a b]/=; rewrite fg. Qed.
 
 End curry.
 

--- a/theories/lib/alt_lib.v
+++ b/theories/lib/alt_lib.v
@@ -310,7 +310,7 @@ Local Open Scope mprog.
 Lemma insert_map (A B : UU0) (f : A -> B) (a : A) :
   insert (f a) \o map f = map f (o) insert a :> (_ -> M _).
 Proof.
-apply boolp.funext; elim => [|y xs IH].
+apply funext; elim => [|y xs IH].
   by rewrite fcompE insertE -(compE (fmap (map f))) (natural ret) compE insertE.
 apply/esym.
 rewrite fcompE insertE alt_fmapDr.
@@ -336,19 +336,19 @@ rewrite -(compE (fmap _)) (natural ret) FIdE.
 rewrite [in X in X [~] _]compE/= (negbTE pa).
 case: ifPn => ph.
 - rewrite -fmap_oE (_ : filter p \o cons h = cons h \o filter p); last first.
-    by apply boolp.funext => x /=; rewrite !compE/= ph.
+    by apply funext => x /=; rewrite !compE/= ph.
   rewrite fmap_oE.
   move: (IH); rewrite fcompE => ->.
   by rewrite fmapE bindretf compE Mmm.
 - rewrite -fmap_oE (_ : filter p \o cons h = filter p); last first.
-    by apply boolp.funext => x /=; rewrite compE/= (negbTE ph).
+    by apply funext => x /=; rewrite compE/= (negbTE ph).
   by move: (IH); rewrite fcompE => ->; rewrite Mmm.
 Qed.
 
 Lemma filter_insertT a : p a ->
   filter p (o) insert a = insert a \o filter p :> (_ -> M _).
 Proof.
-move=> pa; apply boolp.funext; elim => [|h t IH].
+move=> pa; apply funext; elim => [|h t IH].
   by rewrite fcompE !insertE fmapE bindretf compE/= pa.
 rewrite fcompE compE [in RHS]/=; case: ifPn => ph.
 - rewrite [in RHS]insertE.
@@ -361,7 +361,7 @@ rewrite fcompE compE [in RHS]/=; case: ifPn => ph.
 - rewrite [in LHS]insertE alt_fmapDr.
   rewrite -[in X in _ [~] X = _]fmap_oE.
   rewrite (_ : (filter p \o cons h) = filter p); last first.
-    by apply boolp.funext => x /=; rewrite compE/= (negbTE ph).
+    by apply funext => x /=; rewrite compE/= (negbTE ph).
   move: (IH); rewrite fcompE => ->.
   rewrite fmapE bindretf !compE/= pa (negbTE ph) [in RHS]insertE.
   case: (filter _ _) => [|h' t'].
@@ -391,14 +391,14 @@ Qed.
 
 Lemma rev_insert : rev (o) insert a = insert a \o rev :> (_ -> M _).
 Proof.
-apply boolp.funext; elim => [|h t ih].
+apply funext; elim => [|h t ih].
   by rewrite fcompE insertE fmapE bindretf.
 rewrite fcompE insertE compE alt_fmapDr fmapE bindretf compE [in RHS]rev_cons.
 rewrite insert_rcons rev_cons -cats1 rev_cons -cats1 -catA; congr (_ [~] _).
 move: ih; rewrite fcompE compE [X in X -> _]/= => <-.
 rewrite -!fmap_oE.
 congr (fmap _ (insert a t)).
-by apply boolp.funext => s; rewrite !compE/= -rev_cons.
+by apply funext => s; rewrite !compE/= -rev_cons.
 Qed.
 
 End insert_altCIMonad.
@@ -414,7 +414,7 @@ Local Open Scope mprog.
 Lemma iperm_o_map (A B : UU0) (f : A -> B) :
   iperm \o map f = map f (o) iperm :> (_ -> M _).
 Proof.
-apply boolp.funext; elim => [/=|x xs IH].
+apply funext; elim => [/=|x xs IH].
   by rewrite fcompE [iperm _]/= -[in RHS]compE (natural ret).
 by rewrite fcompE [in iperm _]/= fmap_bind -insert_map -bind_fmap -fcompE -IH.
 Qed.
@@ -426,7 +426,7 @@ Variables (A : UU0) (p : pred A).
 (* netys2017 *)
 Lemma iperm_filter : iperm \o filter p = filter p (o) iperm :> (_ -> M _).
 Proof.
-apply boolp.funext; elim => [|h t /[!compE] /= IH].
+apply funext; elim => [|h t /[!compE] /= IH].
   by rewrite fcompE fmapE bindretf.
 case: ifPn => ph.
   rewrite [in LHS]/= IH [in LHS]fcomp_def compE [in LHS]bind_fmap.
@@ -635,7 +635,7 @@ Lemma lrefin_trans A B (b a c : A -> M B) : a `<.=` b -> b `<.=` c -> a `<.=` c.
 Proof. by move => ? ? ?; exact: refin_trans. Qed.
 
 Lemma lrefin_antisym A B (a b : A -> M B) : a `<.=` b -> b `<.=` a -> a = b.
-Proof. move => ? ?; apply boolp.funext => ?; exact: refin_antisym. Qed.
+Proof. move => ? ?; apply funext => ?; exact: refin_antisym. Qed.
 End lrefin_lemmas_altCIMonad.
 
 Lemma refin_ret_insert (M : altCIMonad) (A : UU0) h (t : seq A) :

--- a/theories/lib/fail_lib.v
+++ b/theories/lib/fail_lib.v
@@ -558,7 +558,7 @@ Proof.
 move=> H; rewrite /qperm'; case: s f g H => // h t f g H.
 bind_ext => -[a b] /=.
 rewrite (_ : f = g) //; apply funext_dep => s.
-by apply boolp.funext => ?; exact: H.
+by apply funext => ?; exact: H.
 Qed.
 End qperm_function.
 End qperm_function.
@@ -638,7 +638,7 @@ rewrite (_ : callcc _ = Ret 100) ?bindretf //.
 transitivity (callcc (fun _ : nat -> M nat => Ret 100)); last by rewrite callcc1.
 transitivity (callcc (fun f : nat -> M nat => Ret 10 >>= (fun a => f 100))); first by rewrite callcc2.
 rewrite callcc3 //; congr callcc.
-by apply boolp.funext => g; rewrite bindretf.
+by apply funext => g; rewrite bindretf.
 Qed.
 
 End continuation_example.

--- a/theories/lib/monad_lib.v
+++ b/theories/lib/monad_lib.v
@@ -85,7 +85,7 @@ Lemma mfoldl_rev (T R : UU0) (f : R -> T -> R) (z : R)
     (s : seq T -> M (seq T)) :
   foldl f z (o) (rev (o) s) = foldr (fun x => f^~ x) z (o) s.
 Proof.
-apply boolp.funext => x; rewrite !fcompE 3!fmapE !bindA.
+apply funext => x; rewrite !fcompE 3!fmapE !bindA.
 by bind_ext => ?; rewrite bindretf compE foldl_rev.
 Qed.
 Local Close Scope mprog.
@@ -174,10 +174,10 @@ Definition squaring_actm (A B : UU0) (f : A -> B) : squaring A -> squaring B :=
 Section squaring_instance.
 
 Let squaring_id : FunctorLaws.id squaring_actm.
-Proof. by move=> A /=; apply boolp.funext => -[x1 x2]. Qed.
+Proof. by move=> A /=; apply funext => -[x1 x2]. Qed.
 
 Let squaring_comp : FunctorLaws.comp squaring_actm.
-Proof. by move=> A B C g h /=; apply boolp.funext => -[x1 x2]. Qed.
+Proof. by move=> A B C g h /=; apply funext => -[x1 x2]. Qed.
 
 HB.instance Definition _ :=
   isFunctor.Build squaring squaring_id squaring_comp.
@@ -198,10 +198,10 @@ Definition curry_actm (A B : UU0) (f : A -> B) : curryF X A -> curryF X B :=
   fun x : X * A => (x.1, f x.2).
 
 Let curry_id : FunctorLaws.id curry_actm.
-Proof. by rewrite /FunctorLaws.id => A; apply boolp.funext => -[]. Qed.
+Proof. by rewrite /FunctorLaws.id => A; apply funext => -[]. Qed.
 
 Let curry_comp : FunctorLaws.comp curry_actm.
-Proof. by rewrite /FunctorLaws.comp => A B C g h; apply boolp.funext => -[]. Qed.
+Proof. by rewrite /FunctorLaws.comp => A B C g h; apply funext => -[]. Qed.
 
 HB.instance Definition _ :=
   @isFunctor.Build (curryF X) curry_actm curry_id curry_comp.
@@ -217,13 +217,13 @@ Definition uncurry_actm (X A B : UU0) (f : A -> B) : uncurryF X A -> uncurryF X 
 
 Let uncurry_id X : FunctorLaws.id (@uncurry_actm X).
 Proof.
-rewrite /FunctorLaws.id => A; rewrite /uncurry_actm; apply boolp.funext => ?.
+rewrite /FunctorLaws.id => A; rewrite /uncurry_actm; apply funext => ?.
 by rewrite compidf.
 Qed.
 
 Let uncurry_comp X : FunctorLaws.comp (@uncurry_actm X).
 Proof.
-rewrite /FunctorLaws.comp => A B C g h; rewrite /uncurry_actm; apply boolp.funext => ?.
+rewrite /FunctorLaws.comp => A B C g h; rewrite /uncurry_actm; apply funext => ?.
 by rewrite compE compA.
 Qed.
 
@@ -457,9 +457,9 @@ HB.instance Definition _ := isNatural.Build
 Lemma adjoint_currry : curryF X -| uncurryF X.
 Proof.
 apply: (@AdjointFunctor.mk _ _ curry_eta curry_eps).
-by move=> A; rewrite /TriangularLaws.left; apply boolp.funext => -[].
+by move=> A; rewrite /TriangularLaws.left; apply funext => -[].
 move=> A; rewrite /TriangularLaws.right /uncurryF /curry_eps /curry_eta /uncurryF.
-by rewrite /= /uncurry_actm /= /comp /=; apply boolp.funext => f; apply boolp.funext.
+by rewrite /= /uncurry_actm /= /comp /=; apply funext => f; apply funext.
 Qed.
 
 End adjoint_example.
@@ -698,7 +698,7 @@ Proof. by []. Qed.
 Lemma naturality_mpair (M : monad) (A B : UU0) (f : A -> B) (g : A -> M A):
   (M # f^`2) \o (mpair \o g^`2) = mpair \o ((M # f) \o g)^`2.
 Proof.
-apply boolp.funext => -[a0 a1].
+apply funext => -[a0 a1].
 rewrite compE fmap_bind.
 rewrite compE mpairE compE bind_fmap; bind_ext => a2.
 rewrite fcompE fmap_bind 2!compE bind_fmap; bind_ext => a3.

--- a/theories/lib/state_lib.v
+++ b/theories/lib/state_lib.v
@@ -445,7 +445,7 @@ Lemma promote_assert_sufficient_condition (M : failMonad) (A : UU0) :
   promote_assert M p q.
 Proof.
 move=> right_z p q promotable_pq.
-rewrite /promote_assert; apply: boolp.funext => -[x1 x2].
+rewrite /promote_assert; apply: funext => -[x1 x2].
 rewrite 3![in RHS]compE [in RHS]fmapE.
 rewrite 2![in LHS]compE {1}/bassert [in LHS]bind_fmap !bindA.
 bind_ext => s.
@@ -551,7 +551,7 @@ Proof. by rewrite symbolsE. Qed.
 Lemma symbols_prop1 :
   symbols \o const 1 = (M # wrap) \o const fresh :> (A -> M _).
 Proof.
-apply: boolp.funext => n.
+apply: funext => n.
 transitivity (@symbols _ M 1) => //.
 rewrite symbolsE sequence_cons sequence_nil.
 under eq_bind do rewrite bindretf.
@@ -563,7 +563,7 @@ Local Open Scope mprog.
 Lemma symbols_prop2 :
   symbols \o uaddn = (fmap ucat) \o mpair \o (symbols : _ -> M _)^`2.
 Proof.
-apply: boolp.funext => -[n1 n2].
+apply: funext => -[n1 n2].
 elim: n1 => [|n1 IH].
   rewrite [in LHS]compE uaddnE add0n.
   rewrite compE [in X in _ = _ X]/= squaringE symbols0.

--- a/theories/models/elgot_model.v
+++ b/theories/models/elgot_model.v
@@ -64,12 +64,12 @@ Proof. by []. Qed.
 
 Lemma elgotS_map {X Y} (f : X -> Y) : elgotS # f = (reader S \o M \o writer S) # f.
 Proof.
-apply: boolp.funext => x.
+apply: funext => x.
 rewrite -compA FCompE FCompE//= reader_map.
-apply: boolp.funext => s //=.
+apply: funext => s //=.
 rewrite compE !fmapE//=.
 congr bind.
-by apply: boolp.funext => -[].
+by apply: funext => -[].
 Qed.
 
 (* was wBisimDS in [1] (now it is ElgotS.wB) *)

--- a/theories/models/monad_model.v
+++ b/theories/models/monad_model.v
@@ -124,23 +124,23 @@ Definition insert i s (a : I -> S) j := if i == j then s else a j.
 Lemma insert_insert i s' s a :
   insert i s' (insert i s a) = insert i s' a.
 Proof.
-by apply boolp.funext => j; rewrite /insert; case: ifPn => // /negbTE ->.
+by apply funext => j; rewrite /insert; case: ifPn => // /negbTE ->.
 Qed.
 Lemma insert_same i a s : insert i s a i = s.
 Proof. by rewrite /insert eqxx. Qed.
 Lemma insert_same2 i a : insert i (a i) a = a.
 Proof.
-by apply boolp.funext => j; rewrite /insert; case: ifPn => // /eqP ->.
+by apply funext => j; rewrite /insert; case: ifPn => // /eqP ->.
 Qed.
 Lemma insertC j i v u a : i != j ->
   insert j v (insert i u a) = insert i u (insert j v a).
 Proof.
-move=> h; apply boolp.funext => k; rewrite /insert; case: ifPn => // /eqP <-{k}.
+move=> h; apply funext => k; rewrite /insert; case: ifPn => // /eqP <-{k}.
 by rewrite (negbTE h).
 Qed.
 Lemma insertC2 j i v a : insert j v (insert i v a) = insert i v (insert j v a).
 Proof.
-apply boolp.funext => k; rewrite /insert; case: ifPn => // /eqP <-{k}.
+apply funext => k; rewrite /insert; case: ifPn => // /eqP <-{k}.
 by rewrite if_same.
 Qed.
 
@@ -248,10 +248,10 @@ Let actm (X Y : UU0) : (X -> Y) -> acto X -> acto Y :=
   fun f : X -> Y => fun xs : X * S => match xs with (x, s) => (f x, s) end.
 
 Let writer_id : FunctorLaws.id actm.
-Proof. by move => B; apply: boolp.funext => -[]. Qed.
+Proof. by move => B; apply: funext => -[]. Qed.
 
 Let writer_o : FunctorLaws.comp actm.
-Proof. by move=> X Y Z g h; apply: boolp.funext => -[]. Qed.
+Proof. by move=> X Y Z g h; apply: funext => -[]. Qed.
 
 HB.instance Definition _:= isFunctor.Build acto writer_id writer_o.
 
@@ -321,15 +321,15 @@ Local Notation M := acto.
 Let ret : idfun ~~> M := fun A a => fun s => (a, s).
 Let bind := fun (A B : UU0) (m : M A) (f : A -> M B) => uncurry f \o m.
 Let left_neutral : BindLaws.left_neutral bind ret.
-Proof. by move=> A B a f; apply boolp.funext. Qed.
+Proof. by move=> A B a f; apply funext. Qed.
 Let right_neutral : BindLaws.right_neutral bind ret.
 Proof.
-by move=> A f; apply boolp.funext => s; rewrite /bind compE/=; case: (f s).
+by move=> A f; apply funext => s; rewrite /bind compE/=; case: (f s).
 Qed.
 Let associative : BindLaws.associative bind.
 Proof.
 move=> A B C a b c; rewrite /bind compA; congr (_ \o _).
-by apply boolp.funext => -[].
+by apply funext => -[].
 Qed.
 HB.instance Definition _ :=
   isMonad_ret_bind.Build M left_neutral right_neutral associative.
@@ -351,7 +351,7 @@ Local Notation M := acto.
 Let ret : idfun ~~> M := fun A a => fun k => k a.
 Let bind := fun (A B : UU0) (m : M A) (f : A -> M B) => fun k => m (fun a => f a k).
 Let left_neutral : BindLaws.left_neutral bind ret.
-Proof. by move=> A B a f; apply boolp.funext => Br. Qed.
+Proof. by move=> A B a f; apply funext => Br. Qed.
 Let right_neutral : BindLaws.right_neutral bind ret.
 Proof. by []. Qed.
 Let associative : BindLaws.associative bind.
@@ -371,9 +371,9 @@ Section empty.
 Definition acto (X : UU0) : UU0 := unit.
 Let actm (X Y : UU0) (f : X -> Y) (t : acto X) : acto Y := tt.
 Let func_id : FunctorLaws.id actm.
-Proof. by move=> A; apply boolp.funext => -[]. Qed.
+Proof. by move=> A; apply funext => -[]. Qed.
 Let func_comp : FunctorLaws.comp actm.
-Proof. by move=> A B C f g; apply boolp.funext => -[]. Qed.
+Proof. by move=> A B C f g; apply funext => -[]. Qed.
 HB.instance Definition _ := isFunctor.Build acto func_id func_comp.
 End empty.
 End Empty.
@@ -385,7 +385,7 @@ Local Notation M := [the monad of ListMonad.acto].
 Definition empty : Empty.acto \o M ~~> M := fun A _ => @nil A.
 
 Let naturality_empty : naturality (Empty.acto \o M) M empty.
-Proof. by move=> A B h; exact: boolp.funext. Qed.
+Proof. by move=> A B h; exact: funext. Qed.
 
 HB.instance Definition _ :=
   isNatural.Build (Empty.acto \o M) M empty naturality_empty.
@@ -400,7 +400,7 @@ Definition append : squaring \o M ~~> M :=
 
 Let naturality_append : naturality (squaring \o M) M append.
 Proof.
-move=> A B h; apply boolp.funext => -[s1 s2] /=.
+move=> A B h; apply funext => -[s1 s2] /=.
 rewrite [LHS]fmapE [LHS]list_bindE.
 rewrite [in LHS]map_cat.
 by rewrite [in LHS]flatten_cat.
@@ -426,9 +426,9 @@ Definition acto (X : UU0) := (seq L * X)%type.
 Let actm (X Y : UU0) (f : X -> Y) (t : acto X) : acto Y :=
   let: (w, x) := t in (w, f x).
 Let func_id : FunctorLaws.id actm.
-Proof. by move=> A; apply boolp.funext; case. Qed.
+Proof. by move=> A; apply funext; case. Qed.
 Let func_comp : FunctorLaws.comp actm.
-Proof. by move=> A B C f g; apply boolp.funext; case. Qed.
+Proof. by move=> A B C f g; apply funext; case. Qed.
 HB.instance Definition _ := isFunctor.Build acto func_id func_comp.
 End output.
 End Output.
@@ -456,7 +456,7 @@ Let naturality_output :
   naturality (Output.acto L \o M) M output.
 Proof.
 move=> A B h.
-apply boolp.funext => -[w [x w']].
+apply funext => -[w [x w']].
 by rewrite /output !compE/= catA.
 Qed.
 
@@ -479,7 +479,7 @@ Definition flush : (Flush.acto \o M) ~~> M :=
 
 (* performing a computation in a modified environment *)
 Let naturality_flush : naturality (Flush.acto \o M) M flush.
-Proof. by move=> A B h; apply: boolp.funext => -[]. Qed.
+Proof. by move=> A B h; apply: funext => -[]. Qed.
 
 HB.instance Definition _ := isNatural.Build
   (Flush.acto \o M) M flush naturality_flush.
@@ -510,7 +510,7 @@ Local Notation M := (OutputMonad.acto L).
 Definition output : seq L -> M unit := fun w => output_op _ _ (w, Ret tt).
 Lemma outputE : output = fun w => (tt, w).
 Proof.
-apply boolp.funext => w.
+apply funext => w.
 by rewrite /output /= /monad_model.output /= cats0.
 Qed.
 (* TODO: complete with an interface for the output monad and instantiate *)
@@ -536,9 +536,9 @@ Definition acto (X : UU0) := ((E -> E) * X)%type.
 Let actm (X Y : UU0) (f : X -> Y) (t : acto X) : acto Y :=
   let: (e, x) := t in (e, f x).
 Let func_id : FunctorLaws.id actm.
-Proof. by move=> A; apply boolp.funext => -[]. Qed.
+Proof. by move=> A; apply funext => -[]. Qed.
 Let func_comp : FunctorLaws.comp actm.
-Proof. by move=> A B C g h; apply boolp.funext => -[]. Qed.
+Proof. by move=> A B C g h; apply funext => -[]. Qed.
 HB.instance Definition _ := isFunctor.Build acto func_id func_comp.
 End local.
 End Local.
@@ -568,7 +568,7 @@ Definition local : (Local.acto E \o M)(*(E -> E) * M A*) ~~> M :=
 (* performing a computation in a modified environment *)
 
 Let naturality_local : naturality (Local.acto E \o M) M local.
-Proof. by move=> A B h; apply boolp.funext => -[]. Qed.
+Proof. by move=> A B h; apply funext => -[]. Qed.
 
 HB.instance Definition _ := isNatural.Build
   (Local.acto E \o M) M local naturality_local.
@@ -586,7 +586,7 @@ rewrite /local /=.
 rewrite /actm /=.
 case: t => /= ee m.
 rewrite reader_bindE.
-apply boolp.funext=> x /=.
+apply funext=> x /=.
 Abort.
 
 End environmentops.
@@ -622,9 +622,9 @@ Definition acto (X : UU0) := (X * (Z -> X))%type.
 Let actm (X Y : UU0) (f : X -> Y) (t : acto X) : acto Y :=
   let: (x, h) := t in (f x, fun z => f (h z)).
 Let func_id : FunctorLaws.id actm.
-Proof. by move=> A; apply boolp.funext => -[]. Qed.
+Proof. by move=> A; apply funext => -[]. Qed.
 Let func_comp : FunctorLaws.comp actm.
-Proof. by move=> A B C g h; apply boolp.funext => -[]. Qed.
+Proof. by move=> A B C g h; apply funext => -[]. Qed.
 HB.instance Definition _ := isFunctor.Build acto func_id func_comp.
 End handle.
 End Handle.
@@ -662,7 +662,7 @@ Definition handle : Handle.acto Z \o M ~~> M :=
 
 Let naturality_handle : naturality (Handle.acto Z \o M) M handle.
 
-Proof. by move=> A B h; apply boolp.funext => -[[]]. Qed.
+Proof. by move=> A B h; apply funext => -[[]]. Qed.
 
 HB.instance Definition _ := isNatural.Build
   (Handle.acto Z \o M) M handle naturality_handle.
@@ -698,9 +698,9 @@ Variable S : UU0.
 Definition acto (X : UU0) := S -> X.
 Let actm (X Y : UU0) (f : X -> Y) (t : acto X) : acto Y := f \o t.
 Let func_id : FunctorLaws.id actm.
-Proof. by move=> A; apply boolp.funext. Qed.
+Proof. by move=> A; apply funext. Qed.
 Let func_comp : FunctorLaws.comp actm.
-Proof. by move=> A B C g h; apply boolp.funext. Qed.
+Proof. by move=> A B C g h; apply funext. Qed.
 HB.instance Definition _ := isFunctor.Build acto func_id func_comp.
 End get.
 End StateOpsGet.
@@ -712,9 +712,9 @@ Variable S : UU0.
 Definition acto (X : UU0) := (S * X)%type.
 Let actm (X Y : UU0) (f : X -> Y) (sx : acto X) : acto Y := (sx.1, f sx.2).
 Let func_id : FunctorLaws.id actm.
-Proof. by move=> A; apply boolp.funext => -[]. Qed.
+Proof. by move=> A; apply funext => -[]. Qed.
 Let func_comp : FunctorLaws.comp actm.
-Proof. by move=> A B C g h; apply boolp.funext. Qed.
+Proof. by move=> A B C g h; apply funext. Qed.
 HB.instance Definition _ := isFunctor.Build acto func_id func_comp.
 End put.
 End StateOpsPut.
@@ -728,7 +728,7 @@ Let get : StateOpsGet.acto S \o M ~~> M := fun A k s => k s s.
 
 Let naturality_get : naturality (StateOpsGet.acto S \o M) M get.
 Proof.
-move=> A B h; apply boolp.funext => /= m; apply boolp.funext => s.
+move=> A B h; apply funext => /= m; apply funext => s.
 by rewrite FCompE.
 Qed.
 
@@ -753,7 +753,7 @@ Let put : StateOpsPut.acto S \o M ~~> M :=
 
 Let naturality_put : naturality (StateOpsPut.acto S \o M) M put.
 Proof.
-by move=> A B h; apply boolp.funext => /= -[s m /=]; apply boolp.funext.
+by move=> A B h; apply funext => /= -[s m /=]; apply funext.
 Qed.
 
 HB.instance Definition _ :=
@@ -866,7 +866,7 @@ HB.instance Definition _ := @isMonadFail.Build ListMonad.acto list_fail list_bin
 Definition set_fail : forall A, set A := @set0.
 Let set_bindfailf : BindLaws.left_zero (@bind _) set_fail.
 Proof.
-move=> A B f /=; apply boolp.funext => b; rewrite boolp.propeqE.
+move=> A B f /=; apply funext => b; rewrite boolp.propeqE.
 by split=> // -[a []].
 Qed.
 HB.instance Definition _ := isMonadFail.Build set set_bindfailf.
@@ -880,7 +880,7 @@ Let M : failMonad := option_monad.
 Definition handle : forall A, M A -> M A -> M A :=
   fun A m1 m2 => @handle_op unit _ (m1, (fun _ => m2)).
 Lemma handleE : handle = (fun A m m' => if m is inr x then m else m').
-Proof. by apply funext_dep => A; apply boolp.funext => -[]. Qed.
+Proof. by apply funext_dep => A; apply funext => -[]. Qed.
 Let catchmfail : forall A, right_id fail (@handle A).
 Proof. by move=> A; case => //; case. Qed.
 Let catchfailm : forall A, left_id fail (@handle A).
@@ -936,7 +936,7 @@ End list.
 (* NB: was at the top of the file *)
 Lemma setUDl : @BindLaws.left_distributive _ (fun I A => @bigcup A I) (@setU).
 Proof.
-move=> A B /= p q r; apply boolp.funext => b; rewrite boolp.propeqE; split.
+move=> A B /= p q r; apply funext => b; rewrite boolp.propeqE; split.
 move=> -[a [?|?] ?]; by [left; exists a | right; exists a].
 by rewrite /setU => -[[a ? ?]|[a ? ?]]; exists a => //; [left|right].
 Qed.
@@ -1035,7 +1035,7 @@ Proof. by []. Qed.
 Let st_putget : forall s, st_put s >> st_get = st_put s >> Ret s.
 Proof. by []. Qed.
 Let st_getput : st_get >>= st_put = skip.
-Proof. by move=> *; apply boolp.funext => -[]. Qed.
+Proof. by move=> *; apply funext => -[]. Qed.
 Let st_getget : forall (A : UU0) (k : S -> S -> M A),
       st_get >>= (fun s => st_get >>= k s) = st_get >>= fun s => k s s.
 Proof. by []. Qed.
@@ -1128,7 +1128,7 @@ Compute (sum_break [:: Some 2; Some 6; None; Some 4]).
 
 (* example from Sect. 3.1 of [Wadler, 94] *)
 Goal Ret 1 +m (callcc (fun f => Ret 10 +m (f 100))) = Ret (1 + 100) :> M _.
-Proof. by rewrite /addM bindretf; apply boolp.funext. Abort.
+Proof. by rewrite /addM bindretf; apply funext. Abort.
 
 (* https://xavierleroy.org/mpri/2-4/transformations.pdf *)
 
@@ -1189,13 +1189,13 @@ Section shiftreset_examples.
 Let M : shiftresetMonad nat := [the shiftresetMonad nat of ContMonad.acto nat].
 Goal Ret 1 +m (reset (Ret 10 +m (shift (fun f : _ -> M nat => f (100) >>= f) : M _)) : M _) =
      Ret (1 + (10 + (10 + 100))).
-Proof. by rewrite /addM bindretf; apply boolp.funext. Abort.
+Proof. by rewrite /addM bindretf; apply funext. Abort.
 Goal Ret 1 +m (reset (Ret 10 +m (shift (fun f : _ -> M nat => Ret 100 : M _) : M _)) : M _) =
      Ret (1 + 100).
-Proof. by rewrite /addM bindretf; apply boolp.funext. Abort.
+Proof. by rewrite /addM bindretf; apply funext. Abort.
 Goal Ret 1 +m (reset (Ret 10 +m (shift (fun f : _ -> M nat => f 100 +m f 1000) : M _)) : M _) =
      Ret (1 + ((10 + 100) + (10 + 1000))).
-Proof. by rewrite /addM bindretf; apply boolp.funext. Abort.
+Proof. by rewrite /addM bindretf; apply funext. Abort.
 
 Let N : shiftresetMonad (seq nat) := [the shiftresetMonad (seq nat) of ContMonad.acto (seq nat)].
 Fixpoint perverse (l : seq nat) : N (seq nat) :=
@@ -1214,10 +1214,10 @@ Definition stranger :=
 Goal stranger = Ret 5. by []. Abort.
 
 Goal reset (Ret 2 +m shift (fun k : _ -> M _ => k 3 +m Ret 1 : M _) : M _) = Ret 6 :> M _.
-Proof. by rewrite /addM bindretf; apply boolp.funext. Abort.
+Proof. by rewrite /addM bindretf; apply funext. Abort.
 Goal reset (Ret 2 *m shift (fun k : _ -> M _ => k 4 +m Ret 1 : M _)
                   *m shift (fun k : _ -> M _ => k 3 +m Ret 1 : M _) : M _ ) = Ret 26 :> M _.
-Proof. by rewrite /mulM bindretf; apply boolp.funext. Abort.
+Proof. by rewrite /mulM bindretf; apply funext. Abort.
 
 End shiftreset_examples.
 
@@ -1342,7 +1342,7 @@ Lemma bindE (A B : Type) m (f : A -> [the monad of acto] B) :
                  @` (m s))
     i.
 Proof.
-apply boolp.funext => s.
+apply funext => s.
 rewrite bindE /= /join_of_bind /= /bind /=.
 set lhs := [fset _ _ | _ in _].
 set rhs := [fset _ _ | _ in _].
@@ -1375,7 +1375,7 @@ Let put := (fun s => (fun _ => [fset (tt : choice_of_Type unit,
                                 s : choice_of_Type S)])) : S -> (acto S unit).
 Let putput : forall s s', put s >> put s' = put s'.
 Proof.
-move=> s s'; apply boolp.funext => s''.
+move=> s s'; apply funext => s''.
 rewrite bindE; apply/fsetP => /= x; apply/bigfcupP'/fset1P.
 - by case => /= x0 /imfsetP[/= x1] /fset1P _ -> /fset1P.
 - move=> -> /=.
@@ -1526,17 +1526,17 @@ Definition aget i : M S := fun a => (a i, a).
 Definition aput i s : M unit := fun a => (tt, insert i s a).
 Let aputput i s s' : aput i s >> aput i s' = aput i s'.
 Proof.
-rewrite state_bindE; apply boolp.funext => a/=.
+rewrite state_bindE; apply funext => a/=.
 by rewrite /aput compE/= insert_insert.
 Qed.
 Let aputget i s A (k : S -> M A) : aput i s >> aget i >>= k = aput i s >> k s.
 Proof.
-rewrite state_bindE; apply boolp.funext => a/=.
+rewrite state_bindE; apply funext => a/=.
 by rewrite /aput compE/= insert_same.
 Qed.
 Let agetput i : aget i >>= aput i = skip.
 Proof.
-rewrite state_bindE; apply boolp.funext => a/=.
+rewrite state_bindE; apply funext => a/=.
 by rewrite /aput compE/= insert_same2.
 Qed.
 Let agetget i A (k : S -> S -> M A) :
@@ -1549,13 +1549,13 @@ Proof. by []. Qed.
 Let aputC i j u v : (i != j) \/ (u = v) ->
   aput i u >> aput j v = aput j v >> aput i u.
 Proof.
-by move=> [ij|->{u}]; rewrite !state_bindE /aput; apply/boolp.funext => a/=;
+by move=> [ij|->{u}]; rewrite !state_bindE /aput; apply/funext => a/=;
   [rewrite compE/= insertC|rewrite compE/= insertC2].
 Qed.
 Let aputgetC i j u A (k : S -> M A) : i != j ->
   aput i u >> aget j >>= k = aget j >>= (fun v => aput i u >> k v).
 Proof.
-move=> ij; rewrite /aput !state_bindE; apply boolp.funext => a/=.
+move=> ij; rewrite /aput !state_bindE; apply funext => a/=.
 by rewrite !compE/= state_bindE/= {1}/insert (negbTE ij).
 Qed.
 HB.instance Definition _ := Monad.on M.
@@ -1576,18 +1576,18 @@ Let ret : idfun ~~> M := fun A a => fun s => [set (a, s)].
 Let bind := fun A B (m : M A) (f : A -> M B) => fun s => m s >>= uncurry f.
 Let left_neutral : BindLaws.left_neutral bind ret.
 Proof.
-by move=> X Y x f; apply: boolp.funext => a1; rewrite /bind/= bindretf.
+by move=> X Y x f; apply: funext => a1; rewrite /bind/= bindretf.
 Qed.
 Let right_neutral : BindLaws.right_neutral bind ret.
 Proof.
-move=> X/= m; rewrite /bind; apply: boolp.funext => a1.
+move=> X/= m; rewrite /bind; apply: funext => a1.
 rewrite /ret /uncurry/=; apply/seteqP; split.
   by move=> [x a2]/= [[x' a3]] ma1x'a3/= ->.
 by move=> [x a2] ma1xa2/=; eexists; [exact: ma1xa2|].
 Qed.
 Let associative : BindLaws.associative bind.
 Proof.
-move=> X Y Z /= m f g; rewrite /bind; apply: boolp.funext => a.
+move=> X Y Z /= m f g; rewrite /bind; apply: funext => a.
 by rewrite bindA; bind_ext => -[].
 Qed.
 HB.instance Definition _ :=
@@ -1598,32 +1598,32 @@ Definition aget i : M S := fun s => Ret (ModelArray.aget i s).
 Definition aput i a : M unit := fun s => Ret (ModelArray.aput i a s).
 Let aputput i s s' : aput i s >> aput i s' = aput i s'.
 Proof.
-apply boolp.funext => a/=; rewrite bindE /bind set_bindE.
+apply funext => a/=; rewrite bindE /bind set_bindE.
 by rewrite bigcup_set1/= /aput /ModelArray.aput insert_insert.
 Qed.
 Let aputget i s (A : UU0) (k : S -> M A) :
   aput i s >> aget i >>= k = aput i s >> k s.
 Proof.
-apply boolp.funext => a/=; rewrite !bindE /bind set_bindE.
+apply funext => a/=; rewrite !bindE /bind set_bindE.
 rewrite set_bindE/= bigcup_bigcup !bigcup_set1/= /aput /ModelArray.aput.
 by rewrite bindretf/= insert_same.
 Qed.
 Let agetput i : aget i >>= aput i = skip.
 Proof.
-apply boolp.funext => a/=; rewrite bindE /bind set_bindE bigcup_set1/=.
+apply funext => a/=; rewrite bindE /bind set_bindE bigcup_set1/=.
 by rewrite /aput /ModelArray.aput insert_same2.
 Qed.
 Let agetget i (A : UU0) (k : S -> S -> M A) :
   aget i >>= (fun s => aget i >>= k s) = aget i >>= fun s => k s s.
 Proof.
-apply boolp.funext => a/=; rewrite !bindE /bind !set_bindE/= bigcup_set1/=.
+apply funext => a/=; rewrite !bindE /bind !set_bindE/= bigcup_set1/=.
 by rewrite /aget /ModelArray.aget/= !bindE/= /bind/= !set_bindE/= !bigcup_set1.
 Qed.
 Let agetC i j (A : UU0) (k : S -> S -> M A) :
   aget i >>= (fun u => aget j >>= (fun v => k u v)) =
   aget j >>= (fun v => aget i >>= (fun u => k u v)).
 Proof.
-apply boolp.funext => a/=.
+apply funext => a/=.
 rewrite !bindE /bind/= !set_bindE !bigcup_set1/= /aget /ModelArray.aget/=.
 by rewrite !bindE /bind/= !set_bindE/= !bigcup_set1.
 Qed.
@@ -1631,10 +1631,10 @@ Let aputC i j u v : (i != j) \/ (u = v) ->
   aput i u >> aput j v = aput j v >> aput i u.
 Proof.
 move=> [ij|->{u}].
-  apply boolp.funext => a/=.
+  apply funext => a/=.
   rewrite !bindE /bind/= !set_bindE/= !bigcup_set1/=.
   by rewrite /aput /ModelArray.aput/= insertC.
-apply boolp.funext => a/=.
+apply funext => a/=.
 rewrite !bindE /bind/= !set_bindE/= !bigcup_set1/=.
 by rewrite /aput /ModelArray.aput/= insertC2.
 Qed.
@@ -1642,7 +1642,7 @@ Let aputgetC i j u (A : UU0) (k : S -> M A) : i != j ->
   aput i u >> aget j >>= k = aget j >>= (fun v => aput i u >> k v).
 Proof.
 move=> ij.
-apply boolp.funext => a/=.
+apply funext => a/=.
 rewrite !bindE /bind/= !set_bindE !bigcup_set1/= /aput /ModelArray.aput/=.
 by rewrite bindE /bind/= set_bindE bigcup_set1/= {1}/insert (negbTE ij).
 Qed.
@@ -1650,51 +1650,51 @@ HB.instance Definition _ := isMonadArray.Build
   S I acto aputput aputget agetput agetget agetC aputC aputgetC.
 Let bindfailf : BindLaws.left_zero bind (fun A _ => @set_fail _).
 Proof.
-by move=> A B/= g; apply boolp.funext => a/=; rewrite /bind bindfailf.
+by move=> A B/= g; apply funext => a/=; rewrite /bind bindfailf.
 Qed.
 HB.instance Definition _ := isMonadFail.Build acto bindfailf.
 Definition aalt := fun (T : UU0) (a b : M T) => fun x => a x [~] b x.
 Let altA (T : UU0) : ssrfun.associative (@aalt T).
-Proof. by move=> x y z; apply: boolp.funext => a; rewrite /aalt altA. Qed.
+Proof. by move=> x y z; apply: funext => a; rewrite /aalt altA. Qed.
 Let alt_bindDl : BindLaws.left_distributive bind (@aalt).
 Proof.
-move=> A B/= m1 m2 k; apply boolp.funext => a; rewrite /bind /aalt/=.
+move=> A B/= m1 m2 k; apply funext => a; rewrite /bind /aalt/=.
 by rewrite alt_bindDl.
 Qed.
 HB.instance Definition _ := isMonadAlt.Build M altA alt_bindDl.
 Let altfailm : @BindLaws.left_id _ (@fail [the failMonad of acto])
                                    (@alt [the altMonad of acto]).
 Proof.
-move=> A m; apply boolp.funext => a/=; apply boolp.funext => -[x a1]/=.
+move=> A m; apply funext => a/=; apply funext => -[x a1]/=.
 by rewrite /alt/= /aalt altfailm.
 Qed.
 Let altmfail : @BindLaws.right_id _ (@fail [the failMonad of acto])
                                     (@alt [the altMonad of acto]).
 Proof.
-move=> A m; apply boolp.funext => a/=; apply boolp.funext => -[x a1]/=.
+move=> A m; apply funext => a/=; apply funext => -[x a1]/=.
 by rewrite /alt/= /aalt altmfail.
 Qed.
 HB.instance Definition _ := isMonadNondet.Build M altfailm altmfail.
 Let altmm (A : UU0) : idempotent_op (@alt [the altMonad of M] A).
 Proof.
-move=> m; apply boolp.funext => a/=; apply boolp.funext => -[x a1]/=.
+move=> m; apply funext => a/=; apply funext => -[x a1]/=.
 by rewrite /alt/= /aalt altmm.
 Qed.
 Let altC (A : UU0) : commutative (@alt [the altMonad of M] A).
 Proof.
-move=> m1 m2; apply boolp.funext => a/=; apply boolp.funext => -[x a1]/=.
+move=> m1 m2; apply funext => a/=; apply funext => -[x a1]/=.
 by rewrite /alt/= /aalt altC.
 Qed.
 HB.instance Definition _ := @isMonadAltCI.Build M altmm altC.
 Let bindmfail : BindLaws.right_zero bind (@fail [the failMonad of M]).
 Proof.
-move=> A B /= m; apply boolp.funext => a; apply boolp.funext => -[x a1]/=.
+move=> A B /= m; apply funext => a; apply funext => -[x a1]/=.
 by rewrite /bind/= set_bindE/= bigcup0// => -[].
 Qed.
 HB.instance Definition _ := isMonadFailR0.Build M bindmfail.
 Let alt_bindDr : BindLaws.right_distributive bind (@alt [the altMonad of M]).
 Proof.
-move=> T1 T2 /= A k1 k2; apply boolp.funext => a; apply boolp.funext => -[x a1].
+move=> T1 T2 /= A k1 k2; apply funext => a; apply funext => -[x a1].
 rewrite /bind/= !set_bindE; apply/boolp.propext; split.
   move=> -[[x1 a2] H1]/= H2.
   by rewrite /alt/= /aalt -alt_bindDr set_bindE; exists (x1, a2).
@@ -1888,7 +1888,7 @@ Proof.
 rewrite /= /stateTmonadM /=.
 have FG : MS_functor S ModelMonad.identity = ModelMonad.State.functor S.
   apply: functor_ext => /=; apply funext_dep => A; apply funext_dep => B.
-  apply boolp.funext => f; apply boolp.funext => m; apply boolp.funext => s.
+  apply funext => f; apply funext => m; apply funext => s.
   by rewrite /MS_map /Actm /= /ModelMonad.State.map; destruct (m s).
 apply (@monad_of_ret_bind_ext _ _ _ _ _ _ FG) => /=.
   apply/natural_ext => A a /=; exact: eq_rect_state_ret _ (esym FG).
@@ -1901,7 +1901,7 @@ Proof.
 rewrite /= /exceptTmonadM /ModelMonad.Except.t.
 have FG : MX_functor Z ModelMonad.identity = ModelMonad.Except.functor Z.
   apply: functor_ext => /=; apply funext_dep => A; apply funext_dep => B.
-  apply boolp.funext => f; apply boolp.funext => m.
+  apply funext => f; apply funext => m.
   by rewrite /MX_map /Actm /= /ModelMonad.Except.map; destruct m.
 apply (@monad_of_ret_bind_ext _ _ _ _ _ _ FG) => /=.
   apply/natural_ext => A a /=; exact: (eq_rect_error_ret _ (esym FG)).
@@ -1914,7 +1914,7 @@ Proof.
 rewrite /= /contTmonadM /ModelMonad.Cont.t.
 have FG : MC_functor r ModelMonad.identity = ModelMonad.Cont.functor r.
   apply: functor_ext => /=; apply funext_dep => A; apply funext_dep => B.
-  by apply boolp.funext => f; apply boolp.funext => m.
+  by apply funext => f; apply funext => m.
 apply (@monad_of_ret_bind_ext _ _ _ _ _ _ FG) => /=.
   apply/natural_ext => A a /=; exact: (@eq_rect_cont_ret A r _ (esym FG)).
 set x := @bindC _ _; exact: (@eq_rect_bind_cont r x (esym FG)).
@@ -2043,22 +2043,22 @@ Let Catch (A : UU0) := mapStateT2 (@catch N (A * S)%type).
 
 Let Catchmfail : forall A, right_id (liftS (@fail N A)) (@Catch A).
 Proof.
-move=> A x; rewrite /Catch /mapStateT2; apply boolp.funext => s.
+move=> A x; rewrite /Catch /mapStateT2; apply funext => s.
 by rewrite catchmfail.
 Qed.
 Let Catchfailm : forall A, left_id (liftS (@fail N A)) (@Catch A).
 Proof.
-move=> A x; rewrite /Catch /mapStateT2; apply boolp.funext => s.
+move=> A x; rewrite /Catch /mapStateT2; apply funext => s.
 by rewrite catchfailm.
 Qed.
 Let CatchA : forall A, ssrfun.associative (@Catch A).
 Proof.
-move=> A; rewrite /Catch /mapStateT2 => a b c; apply boolp.funext => s.
+move=> A; rewrite /Catch /mapStateT2 => a b c; apply funext => s.
 by rewrite catchA.
 Qed.
 Let Catchret : forall A x, @left_zero (M A) (M A) (Ret x) (@Catch A).
 Proof.
-move=> A x y; rewrite /Catch /mapStateT2; apply boolp.funext => s.
+move=> A x y; rewrite /Catch /mapStateT2; apply funext => s.
 by rewrite catchret.
 Qed.
 

--- a/theories/models/typed_store_model.v
+++ b/theories/models/typed_store_model.v
@@ -124,7 +124,7 @@ Proof. by move=> H; rewrite /cget H. Qed.
 Let cnewget T (s : coq_type T) A (k : loc T -> coq_type T -> M A) :
   cnew s >>= (fun r => cget r >>= k r) = cnew s >>= (fun r => k r s).
 Proof.
-apply/boolp.funext => e.
+apply/funext => e.
 by rewrite bind_cnew (Some_cget s)// nth_error_rcons_size.
 Qed.
 
@@ -145,7 +145,7 @@ Proof. by move=> H; move: e H => [e] H; rewrite /cput H. Qed.
 Let cnewput T (s t : coq_type T) A (k : loc T -> M A) :
   cnew s >>= (fun r => cput r t >> k r) = cnew t >>= k.
 Proof.
-apply/boolp.funext => e.
+apply/funext => e.
 rewrite bind_cnew 2!MS_bindE.
 by rewrite /cput/= nth_error_rcons_size coerce_Some set_nth_rcons.
 Qed.
@@ -165,7 +165,7 @@ Let cnewC T1 T2 (s : coq_type T1) (t : coq_type T2)
   cnew t >>= (fun r => cnew s >>= k^~ r).
 Proof.
 move=> pmk.
-apply/boolp.funext => -[st].
+apply/funext => -[st].
 rewrite !bind_cnew /fresh_loc /extend_env /= size_rcons.
 Abort.
 *)
@@ -190,7 +190,7 @@ Qed.
 
 Let cgetput T (r : loc T) (s : coq_type T) : cget r >> cput r s = cput r s.
 Proof.
-apply/boolp.funext => e.
+apply/funext => e.
 have [s' H|T' s' H Ts'|H] := ntherrorP e r.
 - by rewrite (Some_cget s').
 - by rewrite MS_bindE (nocoerce_cget H)// (nocoerce_cput _ H).
@@ -225,7 +225,7 @@ Arguments Some_cputget {T} s'.
 
 Let cgetputskip T (r : loc T) : cget r >>= cput r = cget r >> skip.
 Proof.
-apply/boolp.funext => e /=.
+apply/funext => e /=.
 have [s' H|T' s' H Ts'|H] := ntherrorP e r.
 - by rewrite (Some_cget s')// (Some_cget s')// (Some_cput H).
 - by rewrite !MS_bindE (nocoerce_cget H).
@@ -235,7 +235,7 @@ Qed.
 Let cgetget T (r : loc T) (A : UU0) (k : coq_type T -> coq_type T -> M A) :
   cget r >>= (fun s => cget r >>= k s) = cget r >>= fun s => k s s.
 Proof.
-apply/boolp.funext => e /=.
+apply/funext => e /=.
 have [s' H|T' s' H Ts'|H] := ntherrorP e r.
 - by do 3 rewrite (Some_cget s')//.
 - by rewrite !MS_bindE (nocoerce_cget H).
@@ -245,7 +245,7 @@ Qed.
 Let cputget T (r : loc T) (s: coq_type T) (A: UU0) (k: coq_type T -> M A) :
   cput r s >> (cget r >>= k) = cput r s >> k s.
 Proof.
-apply/boolp.funext => e /=.
+apply/funext => e /=.
 have [s' H|T' s' H Ts'|H] := ntherrorP e r.
 - by rewrite (Some_cputget s').
 - by rewrite !MS_bindE (nocoerce_cput _ H).
@@ -269,7 +269,7 @@ Qed.
 Let cputput T (r : loc T) (s s' : coq_type T) :
   cput r s >> cput r s' = cput r s'.
 Proof.
-apply/boolp.funext => e.
+apply/funext => e.
 have [s'' H|T'' s'' H Ts''|H] := ntherrorP e r.
 - by rewrite (Some_cputput _ _ H).
 - by rewrite !MS_bindE (nocoerce_cput _ H)// (nocoerce_cput _ H).
@@ -281,7 +281,7 @@ Let cgetC T1 T2 (r1 : loc T1) (r2 : loc T2) (A : UU0)
   cget r1 >>= (fun u => cget r2 >>= (fun v => k u v)) =
   cget r2 >>= (fun v => cget r1 >>= (fun u => k u v)).
 Proof.
-apply/boolp.funext => e /=.
+apply/funext => e /=.
 have [u Hr1|u T1' Hr1 T1u|Hr1] := ntherrorP e r1.
 - rewrite (Some_cget u)//.
   have [v Hr2|v T2' Hr2 T2v|Hr2] := ntherrorP e r2.
@@ -315,7 +315,7 @@ Let cgetnewD T T' (r : loc T) (s : coq_type T') A
   cget r >>= (fun u => cnew s >>= fun r' => cget r >>= k r' u) =
   cget r >>= (fun u => cnew s >>= fun r' => k r' u u).
 Proof.
-apply/boolp.funext => e.
+apply/funext => e.
 have [u Hr|u T1 Hr T1u|Hr] := ntherrorP e r.
 - by rewrite (Some_cget u)// (Some_cget u)// (cnewgetD_helper _ _ Hr)//.
 - by rewrite !MS_bindE (nocoerce_cget Hr).
@@ -328,7 +328,7 @@ Let cgetnewE T1 T2 (r1 : loc T1) (s : coq_type T2) (A : UU0)
   cget r1 >> (cnew s >>= k1) = cget r1 >> (cnew s >>= k2).
 Proof.
 move=> Hk.
-apply/boolp.funext => e.
+apply/funext => e.
 have [u r1u|T' s' Hr1 T1s'|Hr] := ntherrorP e r1.
 - rewrite (Some_cget u)// (Some_cget u)// !bind_cnew Hk// neq_ltn.
   by case: e r1u => /= e /nth_error_size ->.
@@ -340,7 +340,7 @@ Qed.
 Let cgetputC T1 T2 (r1 : loc T1) (r2 : loc T2) (s : coq_type T2) :
   cget r1 >> cput r2 s = cput r2 s >> cget r1 >> skip.
 Proof.
-apply/boolp.funext => e /=.
+apply/funext => e /=.
 have [u r1u|T1' v1 Hr1 T1v1|Hr1] := ntherrorP e r1.
 - rewrite (Some_cget u)// [in RHS]bindA MS_bindE.
   have [v r2v|T' v r2v T2v|Hr2] := ntherrorP e r2.
@@ -407,7 +407,7 @@ Let cputC T1 T2 (r1 : loc T1) (r2 : loc T2) (s1 : coq_type T1)
   loc_id r1 != loc_id r2 \/ JMeq s1 s2 ->
   cput r1 s1 >> cput r2 s2 = cput r2 s2 >> cput r1 s1.
 Proof.
-move=> H; apply/boolp.funext => e /=.
+move=> H; apply/funext => e /=.
 have [u Hr1|T1' s'd Hr1 T1s'|Hr1] := ntherrorP e r1; last first.
   rewrite MS_bindE None_cput// bindfailf.
   have [v Hr2|T2' s' Hr2 T2s'|Hr2] := ntherrorP e r2; last first.
@@ -456,7 +456,7 @@ Let cputgetC T1 T2 (r1 : loc T1) (r2 : loc T2) (s1 : coq_type T1)
   loc_id r1 != loc_id r2 ->
   cput r1 s1 >> (cget r2 >>= k) = cget r2 >>= (fun v => cput r1 s1 >> k v).
 Proof.
-move=> Hr; apply/boolp.funext => e /=.
+move=> Hr; apply/funext => e /=.
 have [u Hr1|T1' s1' Hr1 T1s'|Hr1] := ntherrorP e r1.
 - have [v Hr2|T' s' Hr2 T2s'|Hr2] := ntherrorP e r2.
   + rewrite (Some_cget _ _ _ _ Hr2).
@@ -487,7 +487,7 @@ Let cputnewC T T' (r : loc T) (s : coq_type T) (s' : coq_type T') A
   cget r >> (cnew s' >>= fun r' => cput r s >> k r') =
   cput r s >> (cnew s' >>= k).
 Proof.
-apply/boolp.funext => e /=.
+apply/funext => e /=.
 have [u Hr|T1 s1' Hr T1s'|Hr] := ntherrorP e r.
 - rewrite (Some_cget _ _ _ _ Hr).
   rewrite [RHS]MS_bindE [in RHS]/cput Hr coerce_Some bindretf/=.

--- a/theories/models/typed_store_transformer.v
+++ b/theories/models/typed_store_transformer.v
@@ -104,14 +104,14 @@ Arguments Some_cget {T r} s.
 Let cnewget T (s : coq_type T) A (k : loc T -> coq_type T -> M A) :
   cnew s >>= (fun r => cget r >>= k r) = cnew s >>= (fun r => k r s).
 Proof.
-apply/boolp.funext => e.
+apply/funext => e.
 by rewrite !bind_cnew (Some_cget s) // nth_error_rcons_size.
 Qed.
 
 Let cnewput T (s t : coq_type T) A (k : loc T -> M A) :
   cnew s >>= (fun r => cput r t >> k r) = cnew t >>= k.
 Proof.
-apply/boolp.funext => e.
+apply/funext => e.
 rewrite !bind_cnew.
 by rewrite /cput/= MS_bindE nth_error_rcons_size coerce_Some set_nth_rcons bindretf.
 Qed.
@@ -142,7 +142,7 @@ Proof. by move=> H; rewrite /cput H. Qed.
 Local Definition cgetput T (r : loc T) (s : coq_type T) :
   cget r >> cput r s = cput r s.
 Proof.
-apply/boolp.funext => e.
+apply/funext => e.
 have [s' H|T' s' H Ts'|H] := ntherrorP e r.
 - by rewrite (Some_cget s').
 - by rewrite MS_bindE (nocoerce_cget H)// (nocoerce_cput _ H) // bindfailf.
@@ -156,7 +156,7 @@ Proof. by move=> H; rewrite /cput/= H coerce_Some/= nth_error_set_nth_id. Qed.
 
 Let cgetputskip T (r : loc T) : cget r >>= cput r = cget r >> skip.
 Proof.
-apply/boolp.funext => e /=.
+apply/funext => e /=.
 have [s' H|T' s' H Ts'|H] := ntherrorP e r.
 - by rewrite (Some_cget s')// (Some_cget s')// (Some_cput H).
 - by rewrite !MS_bindE (nocoerce_cget H) // !bindfailf.
@@ -167,7 +167,7 @@ Let cgetget T (r : loc T) (A : UU0)
     (k : coq_type T -> coq_type T -> M A) :
   cget r >>= (fun s => cget r >>= k s) = cget r >>= fun s => k s s.
 Proof.
-apply/boolp.funext => e /=.
+apply/funext => e /=.
 have [s' H|T' s' H Ts'|H] := ntherrorP e r.
 - by do 3 rewrite (Some_cget s')//.
 - by rewrite !MS_bindE (nocoerce_cget H) // !bindfailf.
@@ -194,7 +194,7 @@ Let cputget T (r : loc T) (s : coq_type T) (A : UU0)
     (k : coq_type T -> M A) :
   cput r s >> (cget r >>= k) = cput r s >> k s.
 Proof.
-apply/boolp.funext => e /=.
+apply/funext => e /=.
 have [s' H|T' s' H Ts'|H] := ntherrorP e r.
 - by rewrite (Some_cputget s').
 - by rewrite !MS_bindE (nocoerce_cput _ H) // !bindfailf.
@@ -217,7 +217,7 @@ Qed.
 Let cputput T (r : loc T) (s s' : coq_type T) :
   cput r s >> cput r s' = cput r s'.
 Proof.
-apply/boolp.funext => e.
+apply/funext => e.
 have [s'' H|T'' s'' H Ts''|H] := ntherrorP e r.
 - by rewrite (Some_cputput _ _ H).
 - by rewrite !MS_bindE (nocoerce_cput _ H)// (nocoerce_cput _ H) // !bindfailf.
@@ -229,7 +229,7 @@ Let cgetC T1 T2 (r1 : loc T1) (r2 : loc T2) (A : UU0)
   cget r1 >>= (fun u => cget r2 >>= (fun v => k u v)) =
   cget r2 >>= (fun v => cget r1 >>= (fun u => k u v)).
 Proof.
-apply/boolp.funext => e /=.
+apply/funext => e /=.
 have [u Hr1|u T1' Hr1 T1u|Hr1] := ntherrorP e r1.
 - rewrite (Some_cget u)//.
   have [v Hr2|v T2' Hr2 T2v|Hr2] := ntherrorP e r2.
@@ -265,7 +265,7 @@ Let cgetnewD T T' (r : loc T) (s : coq_type T') A
   cget r >>= (fun u => cnew s >>= fun r' => cget r >>= k r' u) =
   cget r >>= (fun u => cnew s >>= fun r' => k r' u u).
 Proof.
-apply/boolp.funext => e.
+apply/funext => e.
 have [u Hr|u T1 Hr T1u|Hr] := ntherrorP e r.
 - by rewrite (Some_cget u)// (Some_cget u)// (cnewgetD_helper _ _ Hr)//.
 - by rewrite !MS_bindE (nocoerce_cget Hr) // !bindfailf.
@@ -278,7 +278,7 @@ Let cgetnewE T1 T2 (r1 : loc T1) (s : coq_type T2) (A : UU0)
   cget r1 >> (cnew s >>= k1) = cget r1 >> (cnew s >>= k2).
 Proof.
 move=> Hk.
-apply/boolp.funext => e.
+apply/funext => e.
 have [u r1u|T' s' Hr1 T1s'|Hr] := ntherrorP e r1.
 - rewrite (Some_cget u)// (Some_cget u)// !bind_cnew Hk// neq_ltn.
 - by move: r1u => /= /nth_error_size ->.
@@ -289,7 +289,7 @@ Qed.
 Let cgetputC T1 T2 (r1 : loc T1) (r2 : loc T2) (s : coq_type T2) :
   cget r1 >> cput r2 s = cput r2 s >> cget r1 >> skip.
 Proof.
-apply/boolp.funext => e /=.
+apply/funext => e /=.
 have [u r1u|T1' v1 Hr1 T1v1|Hr1] := ntherrorP e r1.
 - rewrite (Some_cget u)// [in RHS]bindA MS_bindE.
   have [v r2v|T' v r2v T2v|Hr2] := ntherrorP e r2.
@@ -357,7 +357,7 @@ Let cputC T1 T2 (r1 : loc T1) (r2 : loc T2) (s1 : coq_type T1)
   loc_id r1 != loc_id r2 \/ JMeq s1 s2 ->
   cput r1 s1 >> cput r2 s2 = cput r2 s2 >> cput r1 s1.
 Proof.
-move=> H; apply/boolp.funext => e /=.
+move=> H; apply/funext => e /=.
 have [u Hr1|T1' s'd Hr1 T1s'|Hr1] := ntherrorP e r1; last first.
   rewrite MS_bindE None_cput// bindfailf.
   have [v Hr2|T2' s' Hr2 T2s'|Hr2] := ntherrorP e r2; last first.
@@ -409,7 +409,7 @@ Let cputgetC T1 T2 (r1 : loc T1) (r2 : loc T2) (s1 : coq_type T1)
   loc_id r1 != loc_id r2 ->
   cput r1 s1 >> (cget r2 >>= k) = cget r2 >>= (fun v => cput r1 s1 >> k v).
 Proof.
-move=> Hr; apply/boolp.funext => e /=.
+move=> Hr; apply/funext => e /=.
 have [u Hr1|T1' s1' Hr1 T1s'|Hr1] := ntherrorP e r1.
 - have [v Hr2|T' s' Hr2 T2s'|Hr2] := ntherrorP e r2.
   + rewrite (Some_cget _ _ _ _ Hr2).
@@ -440,7 +440,7 @@ Let cputnewC T T' (r : loc T) (s : coq_type T) (s' : coq_type T') A
   cget r >> (cnew s' >>= fun r' => cput r s >> k r') =
   cput r s >> (cnew s' >>= k).
 Proof.
-apply/boolp.funext => e /=.
+apply/funext => e /=.
 have [u Hr|T1 s1' Hr T1s'|Hr] := ntherrorP e r.
 - rewrite (Some_cget _ _ _ _ Hr).
   rewrite [RHS]MS_bindE [in RHS]/cput Hr coerce_Some bindretf/=.


### PR DESCRIPTION
This PR adds `funext` in `preamble.v` just as a copy of `boolp.funext`, to reduce the difference between scripts in `theories`  and `impredicative_set` subdirectories.
