### PR TITLE
make instances on idfun noncanonical

### DIFF
--- a/theories/applications/example_typed_store.v
+++ b/theories/applications/example_typed_store.v
@@ -334,9 +334,9 @@ Section eval.
 Require Import typed_store_transformer.
 Import ModelTypedStoreRun.
 
-Definition M := acto ml_type idfun.
+Definition M := acto ml_type MId.
 
-Definition Env := Env ml_type idfun.
+Definition Env := Env ml_type MId.
 
 Definition empty_env : Env := [::].
 
@@ -367,9 +367,9 @@ Eval vm_compute in it1.
 Definition it2 := Restart it1 (do l <- FromW l; incr l).
 Eval vm_compute in it2.
 
-Local Notation cycle := (cycle idfun M).
-Local Notation rhd := (rhd idfun M).
-Local Notation rtl := (rtl idfun M).
+Local Notation cycle := (cycle MId M).
+Local Notation rhd := (rhd MId M).
+Local Notation rtl := (rtl MId M).
 
 Definition it3 := Restart it2 (cycle ml_bool true false).
 Eval vm_compute in crun (FromW it3).

--- a/theories/applications/monad_composition.v
+++ b/theories/applications/monad_composition.v
@@ -21,8 +21,8 @@ Local Open Scope monae_scope.
 Section comp.
 Variables (M N : monad).
 Definition ret_comp : FId ~~> M \o N := (@ret M) \h (@ret N).
-Lemma naturality_ret : naturality FId [the functor of M \o N] ret_comp.
-Proof. by move=> A B h; rewrite -(natural ((@ret M) \h (@ret N))). Qed.
+Lemma naturality_ret : naturality (FId \o FId) (M \o N) ret_comp.
+Proof. by move=> A B h; rewrite natural. Qed.
 HB.instance Definition _ := isNatural.Build
   FId [the functor of (M \o N)] ret_comp naturality_ret.
 End comp.

--- a/theories/applications/monad_composition.v
+++ b/theories/applications/monad_composition.v
@@ -20,13 +20,13 @@ Local Open Scope monae_scope.
 
 Section comp.
 Variables (M N : monad).
-Definition ret_comp : idfun ~~> M \o N := (@ret M) \h (@ret N).
-Lemma naturality_ret : naturality idfun [the functor of M \o N] ret_comp.
+Definition ret_comp : FId ~~> M \o N := (@ret M) \h (@ret N).
+Lemma naturality_ret : naturality FId [the functor of M \o N] ret_comp.
 Proof. by move=> A B h; rewrite -(natural ((@ret M) \h (@ret N))). Qed.
 HB.instance Definition _ := isNatural.Build
-  idfun [the functor of (M \o N)] ret_comp naturality_ret.
+  FId [the functor of (M \o N)] ret_comp naturality_ret.
 End comp.
-Definition CRet (M N : monad) := [the idfun ~> [the functor of M \o N] of ret_comp M N].
+Definition CRet (M N : monad) := [the FId ~> [the functor of M \o N] of ret_comp M N].
 
 Module Prod.
 Section prod.
@@ -313,13 +313,13 @@ End Swap.
 
 Section nattrans_cast_lemmas.
 Variables (F G : functor).
-Lemma IV : [the functor of idfun \o G] ~> F -> G ~> F.
+Lemma IV : [the functor of FId \o G] ~> F -> G ~> F.
 Proof.
 move=> [s [] [GFs]].
 apply: (@Nattrans.Pack [the functor of G] F _ (Nattrans.Class (isNatural.Axioms_ _ _ _))).
 exact: GFs.
 Qed.
-Lemma VI : [the functor of G \o idfun] ~> F -> G ~> F.
+Lemma VI : [the functor of G \o FId] ~> F -> G ~> F.
 Proof.
 move=> [s [] [GFs]].
 apply: (@Nattrans.Pack [the functor of G] F _ (Nattrans.Class (isNatural.Axioms_ _ _ _))).

--- a/theories/core/category.v
+++ b/theories/core/category.v
@@ -294,11 +294,11 @@ Arguments functor_o_head [C D a b c g h d] F.
 
 Section functorid.
 Variables C : category.
-Definition id_f (A B : C) (f : {hom A -> B}) := f.
-Lemma id_id : FunctorLaws.id id_f. Proof. by []. Qed.
-Lemma id_comp : FunctorLaws.comp id_f. Proof. by []. Qed.
-HB.instance Definition _ := isFunctor.Build _ _ idfun id_id id_comp.
-Definition FId : {functor C -> C} := [the {functor _ -> _} of idfun].
+Local Notation id_f := (fun A B : C => @idfun {hom A -> B}).
+Let id_id : FunctorLaws.id id_f. Proof. by []. Qed.
+Let id_comp : FunctorLaws.comp id_f. Proof. by []. Qed.
+Let id_class := isFunctor.Build _ _ idfun id_id id_comp.
+Definition FId := HB.pack_for {functor C -> C} idfun id_class.
 Lemma FIdf (A B : C) (f : {hom A -> B}) : FId # f = f.
 Proof. by []. Qed.
 End functorid.
@@ -1004,7 +1004,7 @@ Let F := [the functor of acto].
 Lemma actmE (a b : CT) (h : {hom a -> b}) : (F # h)%monae = (M # h)%category.
 Proof. by congr (category.actm M); apply hom_ext. Qed.
 
-Definition ret_ : forall A, idfun A -> F A :=
+Definition ret_ : forall A, FId A -> F A :=
   fun A (a : A) => @category.ret _ M A a.
 
 Definition join_ : forall A, [the functor of F \o F] A -> F A :=

--- a/theories/core/hierarchy.v
+++ b/theories/core/hierarchy.v
@@ -40,7 +40,7 @@ From HB Require Import structures.
 (*                >>= == notation for the standard bind operator              *)
 (*             m >> f := m >>= (fun _ => f)                                   *)
 (*              monad == type of monads                                       *)
-(*                Ret == natural transformation idfun ~> M for a monad M      *)
+(*                Ret == natural transformation FId ~> M for a monad M      *)
 (*               Join == natural transformation M \o M ~> M for a monad M     *)
 (* ```                                                                        *)
 (*                                                                            *)
@@ -197,10 +197,11 @@ Section functorid.
 Let id_actm (A B : UU0) (f : A -> B) : idfun A -> idfun B := f.
 Let id_id : FunctorLaws.id id_actm. Proof. by []. Qed.
 Let id_comp : FunctorLaws.comp id_actm. Proof. by []. Qed.
-HB.instance Definition _ := isFunctor.Build idfun id_id id_comp.
+Let id_class := isFunctor.Build idfun id_id id_comp.
+Definition FId := HB.pack_for functor idfun id_class.
 End functorid.
 
-Lemma FIdE (A B : UU0) (f : A -> B) : idfun # f = f. Proof. by []. Qed.
+Lemma FIdE (A B : UU0) (f : A -> B) : FId # f = f. Proof. by []. Qed.
 
 Section functor_composition.
 Variables F G : functor.
@@ -313,7 +314,7 @@ Qed.*)
 Module JoinLaws.
 Section join_laws.
 Context {F : functor}.
-Variables (ret : idfun ~~> F) (join : F \o F ~~> F).
+Variables (ret : FId ~~> F) (join : F \o F ~~> F).
 Arguments ret {_}.
 Arguments join {A}.
 
@@ -366,7 +367,7 @@ End bindlaws.
 End BindLaws.
 
 HB.mixin Record Functor_isMonad (F : UU0 -> UU0) of Functor F := {
-  ret : idfun ~> F ;
+  ret : FId ~> F ;
   join : F \o F ~> F ;
   bind : forall (A B : UU0), F A -> (A -> F B) -> F B ;
   bindE : forall (A B : UU0) (f : A -> F B) (m : F A),
@@ -394,7 +395,7 @@ Arguments bindmret {s} [A].
 Arguments bindA {s} [A B C].
 
 HB.factory Record isMonad (F : UU0 -> UU0) of Functor F := {
-  ret : idfun ~> F ;
+  ret : FId ~> F ;
   join : F \o F ~> F ;
   bind : forall (A B : UU0), F A -> (A -> F B) -> F B ;
   bindE : forall (A B : UU0) (f : A -> F B) (m : F A),
@@ -468,7 +469,7 @@ Definition bind_of_join (F : functor) (j : F \o F ~~> F)
   j B ((F # f) m).
 
 HB.factory Record isMonad_ret_join (F : UU0 -> UU0) of isFunctor F := {
-  ret : idfun ~> F ;
+  ret : FId ~> F ;
   join : F \o F ~> F ;
   joinretM : JoinLaws.left_unit ret join ;
   joinMret : JoinLaws.right_unit ret join ;
@@ -520,7 +521,7 @@ HB.instance Definition _ := isFunctor.Build M actm_id actm_comp.
 Let F := [the functor of M].
 Local Notation FF := [the functor of F \o F].
 
-Let ret_naturality : naturality idfun F ret.
+Let ret_naturality : naturality FId F ret.
 Proof.
 move=> a b h.
 rewrite FIdE /hierarchy.actm /= /actm; apply: boolp.funext => m /=.
@@ -528,7 +529,7 @@ by rewrite compE bindretf.
 Qed.
 
 HB.instance Definition _ :=
-  isNatural.Build idfun F (ret : idfun ~~> F) ret_naturality.
+  isNatural.Build FId F (ret : FId ~~> F) ret_naturality.
 
 Let join' : FF ~~> F := fun _ m => bind m idfun.
 

--- a/theories/core/monad_transformer.v
+++ b/theories/core/monad_transformer.v
@@ -96,7 +96,7 @@ Variables (S : UU0) (M : monad).
 
 Definition MS := fun A : UU0 => S -> M (A * S)%type.
 
-Definition retS : idfun ~~> MS := fun A : UU0 => curry Ret.
+Definition retS : FId ~~> MS := fun A : UU0 => curry Ret.
 
 Definition bindS (A B : UU0) (m : MS A) f : MS B := fun s => m s >>= uncurry f.
 
@@ -216,7 +216,7 @@ Variables (Z : UU0) (* the type of exceptions *) (M : monad).
 Definition MX := fun X : UU0 => M (Z + X)%type.
 
 (* unit and bind operator of the transformed monad *)
-Definition retX : idfun ~~> MX := fun X x => Ret (inr x).
+Definition retX : FId ~~> MX := fun X x => Ret (inr x).
 
 Definition bindX X Y (t : MX X) (f : X -> MX Y) : MX Y :=
   t >>= fun c => match c with inl z => Ret (inl z) | inr x => f x end.
@@ -336,7 +336,7 @@ Variables (R : UU0) (M : monad).
 
 Definition MEnv := fun A : UU0 => R -> M A.
 
-Definition retEnv : idfun ~~> MEnv := fun (A : UU0) a r => Ret a.
+Definition retEnv : FId ~~> MEnv := fun (A : UU0) a r => Ret a.
 
 Definition bindEnv A B (m : MEnv A) f : MEnv B :=
   fun r => m r >>= (fun a => f a r).
@@ -388,7 +388,7 @@ Variables (R : UU0) (M : monad).
 
 Definition MO (X : UU0) := M (X * seq R)%type.
 
-Definition retO : idfun ~~> MO := fun (A : UU0) a => Ret (a, [::]).
+Definition retO : FId ~~> MO := fun (A : UU0) a => Ret (a, [::]).
 
 Definition bindO A B (m : MO A) (f : A -> MO B) : MO B :=
   m >>= (fun o => let: (x, w) := o in f x >>=
@@ -462,7 +462,7 @@ Variables (r : UU0) (M : monad).
 
 Definition MC : UU0 -> UU0 := fun A => (A -> M r) -> M r %type.
 
-Definition retC : idfun ~~> MC := fun (A : UU0) (a : A) k => k a.
+Definition retC : FId ~~> MC := fun (A : UU0) (a : A) k => k a.
 
 Definition bindC A B (m : MC A) f : MC B := fun k => m (f^~ k).
 

--- a/theories/lib/monad_lib.v
+++ b/theories/lib/monad_lib.v
@@ -301,18 +301,18 @@ Lemma fmap_oE (M : functor) (A B C : UU0) (f : A -> B) (g : C -> A) (m : M C) :
   (M # (f \o g)) m = (M # f) ((M # g) m).
 Proof. by rewrite functor_o. Qed.
 
-Definition NId (C : functor) := fun A => @idfun (C A).
-
 Section id_natural_transformation.
 Variables C : functor.
 
-Let natural_id : naturality C C (@NId C). Proof. by []. Qed.
+Let nid : C ~~> C := fun A => @idfun (C A).
 
-HB.instance Definition _ := isNatural.Build C C (@NId C) natural_id.
+Let natural_nid : naturality C C nid. Proof. by []. Qed.
+
+Let class := isNatural.Build C C nid natural_nid.
+
+Definition NId := HB.pack_for (C ~> C) nid class.
 
 End id_natural_transformation.
-
-Arguments NId C [A].
 
 Definition vcomp (C D E : functor) (g : D ~> E) (f : C ~> D) :=
   fun A : UU0 => g A \o f A.

--- a/theories/lib/monad_lib.v
+++ b/theories/lib/monad_lib.v
@@ -393,18 +393,18 @@ Lemma functor_app_natural_hcomp (S F G : functor) (nt : F ~> G) :
   S ## nt = [the _ ~> _ of NId S] \h nt.
 Proof. by apply nattrans_ext => a; rewrite functor_app_naturalE. Qed.
 
-Definition fork : idfun ~~> squaring := fun (A : UU0) (a : A) => (a, a).
+Definition fork : FId ~~> squaring := fun (A : UU0) (a : A) => (a, a).
 
 Section natural_transformation_example.
 
 Let fork_natural : naturality _ _ fork. Proof. by []. Qed.
 
-HB.instance Definition _ := isNatural.Build idfun squaring fork fork_natural.
+HB.instance Definition _ := isNatural.Build FId squaring fork fork_natural.
 
 End natural_transformation_example.
 
-Definition eta_type (f g : functor) := idfun ~> g \o f.
-Definition eps_type (f g : functor) := f \o g ~> idfun.
+Definition eta_type (f g : functor) := FId ~> g \o f.
+Definition eps_type (f g : functor) := f \o g ~> FId.
 
 Module TriangularLaws.
 Section triangularlaws.
@@ -436,16 +436,16 @@ Notation "F -| G" := (AdjointFunctor.t F G).
 Section adjoint_example.
 Variable (X : UU0).
 
-Definition curry_eps : curryF X \o uncurryF X ~~> idfun :=
+Definition curry_eps : curryF X \o uncurryF X ~~> FId :=
   fun (A : UU0) (af : X * (X -> A)) => af.2 af.1.
 
-Let curry_eps_naturality : naturality (curryF X \o uncurryF X) idfun curry_eps.
+Let curry_eps_naturality : naturality (curryF X \o uncurryF X) FId curry_eps.
 Proof. by []. Qed.
 
 HB.instance Definition _ := isNatural.Build
-  (curryF X \o uncurryF X) idfun curry_eps curry_eps_naturality.
+  (curryF X \o uncurryF X) FId curry_eps curry_eps_naturality.
 
-Definition curry_eta : idfun ~~> uncurryF X \o curryF X :=
+Definition curry_eta : FId ~~> uncurryF X \o curryF X :=
   fun (A : UU0) (a : A) => pair^~ a.
 
 Let curry_eta_naturality : naturality _ (uncurryF X \o curryF X) curry_eta.
@@ -546,10 +546,10 @@ Hypothesis H : F -| U.
 Let eta : eta_type F U := AdjointFunctor.eta H.
 Let eps : eps_type F U := AdjointFunctor.eps H.
 
-Definition uni : idfun ~~> (U0 \o U) \o (F \o F0) :=
+Definition uni : FId ~~> (U0 \o U) \o (F \o F0) :=
   fun A : UU0 => U0 # eta (F0 A) \o eta0 A.
 
-Let uni_naturality : naturality idfun ((U0 \o U) \o (F \o F0)) uni.
+Let uni_naturality : naturality FId ((U0 \o U) \o (F \o F0)) uni.
 Proof.
 move=> A B h; rewrite FIdE.
 rewrite -[RHS]compA.
@@ -564,7 +564,7 @@ Qed.
 
 HB.instance Definition _ := isNatural.Build _ _ uni uni_naturality.
 
-Definition couni : (F \o F0) \o (U0 \o U) ~~> idfun :=
+Definition couni : (F \o F0) \o (U0 \o U) ~~> FId :=
   fun A : UU0 => eps A \o F # eps0 (U A).
 
 Let couni_naturality : naturality ((F \o F0) \o (U0 \o U)) _ couni.
@@ -640,11 +640,11 @@ Qed.
 
 End algebraic_operation_interface.
 
-(*Lemma monad_of_ret_bind_ext (F G : functor) (RET1 : idfun ~> F) (RET2 : idfun ~> G)
+(*Lemma monad_of_ret_bind_ext (F G : functor) (RET1 : FId ~> F) (RET2 : FId ~> G)
   (bind1 : forall A B : UU0, F A -> (A -> F B) -> F B)
   (bind2 : forall A B : UU0, G A -> (A -> G B) -> G B) :
   forall (FG : F = G),
-  RET1 = eq_rect _ (fun m : functor => idfun ~> m) RET2 _ ((*beuh*) (esym FG)) ->
+  RET1 = eq_rect _ (fun m : functor => FId ~> m) RET2 _ ((*beuh*) (esym FG)) ->
   bind1 = eq_rect _ (fun m : functor => forall A B : UU0, m A -> (A -> m B) -> m B) bind2 _ (esym FG) ->
   forall H1 K1 H2 K2 H3 K3,
   Monad_of_ret_bind F RET1 bind1 H1 H2 H3 =

--- a/theories/models/delay_model.v
+++ b/theories/models/delay_model.v
@@ -35,7 +35,7 @@ CoInductive Delay (A : UU0) : Type :=
 
 Local Notation M := Delay.
 
-Let ret : idfun ~~> M := @Now.
+Let ret : FId ~~> M := @Now.
 
 Let bind := fun A B (m : M A) (f : A -> M B) =>
   (cofix bind_ u := match u with

--- a/theories/models/gcm_model.v
+++ b/theories/models/gcm_model.v
@@ -301,7 +301,7 @@ Let eps0' : F0 \O U0 ~~> FId := fun a =>
 
 Let eps0'_natural : naturality _ _ eps0'.
 Proof.
-move=> C D f; rewrite FCompE /= /id_f; apply funext => d /=.
+move=> C D f; rewrite FCompE /=; apply funext => d /=.
 by rewrite compE Convn_of_fsdistmap.
 Qed.
 
@@ -714,7 +714,7 @@ Lemma gcm_retE (T : Type) (x : choice_of_Type T) :
 Proof.
 rewrite /= /ret_ /Monad_of_category_monad.ret /=.
 rewrite !HCompId !HIdComp /=.
-rewrite /id_f /= /etaC.
+rewrite /= /etaC.
 unlock => /=.
 by rewrite eta0E eta1E.
 Qed.

--- a/theories/models/monad_model.v
+++ b/theories/models/monad_model.v
@@ -149,9 +149,9 @@ End assoc.
 Module IdentityMonad.
 Section identitymonad.
 Let bind := fun A B (a : A) (f : A -> B) => f a.
-Let left_neutral : BindLaws.left_neutral bind (NId idfun).
+Let left_neutral : BindLaws.left_neutral bind (NId FId).
 Proof. by []. Qed.
-Let right_neutral : BindLaws.right_neutral bind (NId idfun).
+Let right_neutral : BindLaws.right_neutral bind (NId FId).
 Proof. by []. Qed.
 Let associative : BindLaws.associative bind. Proof. by []. Qed.
 Let acto := (@idfun UU0).
@@ -165,7 +165,7 @@ Module ListMonad.
 Section listmonad.
 Definition acto := fun A : UU0 => seq A.
 Local Notation M := acto.
-Let ret : idfun ~~> M := fun (A : UU0) x => (@cons A) x [::].
+Let ret : FId ~~> M := fun (A : UU0) x => (@cons A) x [::].
 Let bind := fun A B (m : M A) (f : A -> M B) => flatten (map f m).
 Let left_neutral : BindLaws.left_neutral bind ret.
 Proof. by move=> A B m f; rewrite /bind /ret /= cats0. Qed.
@@ -191,7 +191,7 @@ Section setmonad.
 Local Open Scope classical_set_scope.
 Definition acto := set.
 Local Notation M := acto.
-Let ret : idfun ~~> M := @set1.
+Let ret : FId ~~> M := @set1.
 Let bind := fun A B => @bigcup B A.
 Let left_neutral : BindLaws.left_neutral bind ret.
 Proof. move=> ? ? ? ?; exact: bigcup_set1. Qed.
@@ -216,7 +216,7 @@ Section exceptmonad.
 Variable E : UU0.
 Definition acto := fun A : UU0 => (E + A)%type.
 Local Notation M := acto.
-Let ret : idfun ~~> M := @inr E.
+Let ret : FId ~~> M := @inr E.
 Let bind := fun A B (m : M A) (f : A -> M B) =>
   match m with inl z => inl z | inr b => f b end.
 Let left_neutral : BindLaws.left_neutral bind ret.
@@ -264,7 +264,7 @@ Section output.
 Variable L : UU0.
 Definition acto := fun X : UU0 => (X * seq L)%type.
 Local Notation M := acto.
-Let ret : idfun ~~> M := fun A a => (a, [::]).
+Let ret : FId ~~> M := fun A a => (a, [::]).
 Let bind := fun (A B : UU0) (m : M A) (f : A -> M B) =>
   let: (x, w) := m in let: (x', w') := f x in (x', w ++ w').
 Let left_neutral : BindLaws.left_neutral bind ret.
@@ -292,7 +292,7 @@ Section reader.
 Variable E : UU0.
 Definition acto := fun A : UU0 => E -> A.
 Local Notation M := acto.
-Definition ret : idfun ~~> M := fun A x => fun e => x.
+Definition ret : FId ~~> M := fun A x => fun e => x.
 (* computation that ignores the environment *)
 Let bind := fun (A B : UU0) (m : M A) (f : A -> M B) => fun e => f (m e) e.
 (* binds m f applied the same environment to m and to the result of f *)
@@ -318,7 +318,7 @@ Section state.
 Variable S : UU0. (* type of states *)
 Definition acto := fun A : UU0 => S -> A * S.
 Local Notation M := acto.
-Let ret : idfun ~~> M := fun A a => fun s => (a, s).
+Let ret : FId ~~> M := fun A a => fun s => (a, s).
 Let bind := fun (A B : UU0) (m : M A) (f : A -> M B) => uncurry f \o m.
 Let left_neutral : BindLaws.left_neutral bind ret.
 Proof. by move=> A B a f; apply boolp.funext. Qed.
@@ -348,7 +348,7 @@ Section cont.
 Variable r : UU0. (* the type of answers *)
 Definition acto := fun A : UU0 => (A -> r) -> r.
 Local Notation M := acto.
-Let ret : idfun ~~> M := fun A a => fun k => k a.
+Let ret : FId ~~> M := fun A a => fun k => k a.
 Let bind := fun (A B : UU0) (m : M A) (f : A -> M B) => fun k => m (fun a => f a k).
 Let left_neutral : BindLaws.left_neutral bind ret.
 Proof. by move=> A B a f; apply boolp.funext => Br. Qed.
@@ -1291,7 +1291,7 @@ Definition acto : Type -> Type :=
   fun A => S -> {fset (choice_of_Type A * choice_of_Type S)}.
 Local Notation M := acto.
 
-Let ret : idfun ~~> M := fun A (a : A) s =>
+Let ret : FId ~~> M := fun A (a : A) s =>
   [fset (a : choice_of_Type A, s : choice_of_Type S)].
 
 Let bind := fun A B (m : acto A)
@@ -1572,7 +1572,7 @@ Variable (S : UU0) (I : eqType).
 Implicit Types i j : I.
 Definition acto (A : UU0) := (I -> S) -> SetMonad.acto (A * (I -> S))%type.
 Local Notation M := acto.
-Let ret : idfun ~~> M := fun A a => fun s => [set (a, s)].
+Let ret : FId ~~> M := fun A a => fun s => [set (a, s)].
 Let bind := fun A B (m : M A) (f : A -> M B) => fun s => m s >>= uncurry f.
 Let left_neutral : BindLaws.left_neutral bind ret.
 Proof.
@@ -1740,7 +1740,7 @@ Variable (S : UU0) (I : eqType).
 Implicit Types i j : I.
 Definition acto (A : UU0) := unit.
 Local Notation M := acto.
-Let ret : idfun ~~> M := fun A a => tt.
+Let ret : FId ~~> M := fun A a => tt.
 Let bind := fun A B (m : M A) (f : A -> M B) => tt : M B.
 Let left_neutral : BindLaws.left_neutral bind ret.
 Proof. by move=> ? ? x f; case: (f x). Qed.

--- a/theories/models/monad_model.v
+++ b/theories/models/monad_model.v
@@ -146,7 +146,6 @@ Qed.
 
 End assoc.
 
-Module IdentityMonad.
 Section identitymonad.
 Let bind := fun A B (a : A) (f : A -> B) => f a.
 Let left_neutral : BindLaws.left_neutral bind (NId FId).
@@ -155,11 +154,10 @@ Let right_neutral : BindLaws.right_neutral bind (NId FId).
 Proof. by []. Qed.
 Let associative : BindLaws.associative bind. Proof. by []. Qed.
 Let acto := (@idfun UU0).
-HB.instance Definition _ := isMonad_ret_bind.Build
+Let class := isMonad_ret_bind.Build
   acto left_neutral right_neutral associative.
+Definition MId := HB.pack_for monad idfun class.
 End identitymonad.
-End IdentityMonad.
-HB.export IdentityMonad.
 
 Module ListMonad.
 Section listmonad.
@@ -1135,7 +1133,7 @@ Proof. by rewrite /addM bindretf; apply boolp.funext. Abort.
 Fixpoint list_iter (M : monad) A (f : A -> M unit) (s : seq A) : M unit :=
   if s is h :: t then f h >> list_iter f t else Ret tt.
 
-Compute (@list_iter [the monad of idfun] nat (fun a => Ret tt) [:: O; 1; 2]).
+Compute (@list_iter MId nat (fun a => Ret tt) [:: O; 1; 2]).
 
 Definition list_find (M : contMonad) (A : UU0) (p : pred A) (s : seq A) : M _ :=
   callcc (fun k => list_iter (fun x => if p x then (*Throw*) k (Some x) else Ret tt) s >> Ret None).
@@ -1883,7 +1881,7 @@ End eq_rect_bind.
 (*Section instantiations_with_the_identity_monad.
 
 Lemma stateT_id_ModelState S :
-  stateT S [the monad of idfun] = [the monad of StateMonad.acto S].
+  stateT S MId = [the monad of StateMonad.acto S].
 Proof.
 rewrite /= /stateTmonadM /=.
 have FG : MS_functor S ModelMonad.identity = ModelMonad.State.functor S.
@@ -1924,7 +1922,7 @@ End instantiations_with_the_identity_monad.*)
 
 Section monad_transformer_calcul.
 
-Let contTi T := MC T [the monad of idfun].
+Let contTi T := MC T MId.
 
 Definition break_if_none (m : monad) (break : _) (acc : nat) (x : option nat) : m nat :=
   if x is Some x then Ret (x + acc) else break acc.

--- a/theories/models/proba_model.v
+++ b/theories/models/proba_model.v
@@ -70,7 +70,7 @@ Variable R : realType.
 
 Definition acto : UU0 -> UU0 := fun A => R.-dist (choice_of_Type A).
 
-Definition ret : idfun ~~> acto :=
+Definition ret : FId ~~> acto :=
   fun A a => fsdist1 (a : choice_of_Type A).
 
 Definition bind : forall A B, acto A -> (A -> acto B) -> acto B :=

--- a/theories/models/typed_store_transformer.v
+++ b/theories/models/typed_store_transformer.v
@@ -7,7 +7,7 @@ Require Import preamble.
 From HB Require Import structures.
 Require Import hierarchy monad_lib fail_lib state_lib monad_transformer.
 Require Import typed_store_universe delay_model elgot_model.
-Require monad_model.
+Require Import monad_model.
 
 (**md**************************************************************************)
 (* # Model of the typed store monad built using transformers                  *)
@@ -482,7 +482,6 @@ End ModelTypedStore.
 
 Module ModelTypedStoreRun.
 Export ModelTypedStore.
-Import (canonicals)monad_model.
 
 Section ModelTypedStoreRun.
 Variables (MLU : ML_universe) (N : monad).
@@ -491,7 +490,7 @@ Local Notation coq_type := (@coq_type MLU N).
 
 Local Notation ml_type := (MLU : Type).
 
-Definition acto := ModelTypedStore.acto ml_type N idfun.
+Definition acto := ModelTypedStore.acto ml_type N MId.
 Local Notation M := acto.
 
 Local Notation loc := (@loc ml_type locT_nat).


### PR DESCRIPTION
The instances of functor, monad, natural transformation on `idfun` has been canonical,
and this caused problems when moving to universe polymorphic `idfun` in another PR.

This PR turns them into noncanonical `Definition FId/MId/NId := HB.pack_for ...`.

There were not many adaptations needed, and moreover,
the code has become clearer by distinguishing those instances from bare occurrences of `idfun`.